### PR TITLE
Improve demo panel/menus for touchscreen (separation of icons)

### DIFF
--- a/recipes-graphics/wayland/files/weston.ini
+++ b/recipes-graphics/wayland/files/weston.ini
@@ -14,7 +14,7 @@ command=/usr/bin/weston --backend=rdp-backend.so --shell=fullscreen-shell.so --n
 background-image=/usr/share/wpe_white.jpg
 background-color=0xffdddddd
 background-type=scale-crop
-clock-format=minutes
+clock-format=seconds-24h
 panel-position=top
 panel-color=0x90000000
 locking=false
@@ -30,9 +30,27 @@ displayname=System terminal
 path=/usr/bin/weston-terminal
 
 [launcher]
+icon=/usr/share/24x24-blank.png
+displayname=Separator
+path=/usr/bin/false
+
+[launcher]
 icon=/usr/share/icons/Adwaita/24x24/status/network-wireless-acquiring-symbolic.symbolic.png
 displayname=Configure WiFi network
 path=/usr/bin/weston-terminal-configure-network
+
+[launcher]
+icon=/usr/share/24x24-blank.png
+displayname=Separator
+path=/usr/bin/false
+[launcher]
+icon=/usr/share/24x24-blank.png
+displayname=Separator
+path=/usr/bin/false
+[launcher]
+icon=/usr/share/24x24-blank.png
+displayname=Separator
+path=/usr/bin/false
 
 [launcher]
 icon=/usr/share/icons/Adwaita/24x24/places/user-home-symbolic.symbolic.png
@@ -40,9 +58,19 @@ displayname=Go to WPE WebKit website
 path=/usr/bin/demo-wpe-website
 
 [launcher]
+icon=/usr/share/24x24-blank.png
+displayname=Separator
+path=/usr/bin/false
+
+[launcher]
 icon=/usr/share/icons/Adwaita/24x24/apps/web-browser-symbolic.symbolic.png
 displayname=Go to DuckDuckGo homepage
 path=/usr/bin/demo-wpe-duckduckgo
+
+[launcher]
+icon=/usr/share/24x24-blank.png
+displayname=Separator
+path=/usr/bin/false
 
 [launcher]
 icon=/usr/share/icons/Adwaita/24x24/actions/go-next-symbolic-rtl.symbolic.png
@@ -50,9 +78,19 @@ displayname=Previous page
 path=/usr/bin/cog-fdo-ctl previous
 
 [launcher]
+icon=/usr/share/24x24-blank.png
+displayname=Separator
+path=/usr/bin/false
+
+[launcher]
 icon=/usr/share/icons/Adwaita/24x24/actions/go-next-symbolic.symbolic.png
 displayname=Next page
 path=/usr/bin/cog-fdo-ctl next
+
+[launcher]
+icon=/usr/share/24x24-blank.png
+displayname=Separator
+path=/usr/bin/false
 
 [launcher]
 icon=/usr/share/icons/Adwaita/24x24/actions/view-refresh-symbolic.symbolic.png
@@ -60,12 +98,21 @@ displayname=Page reload
 path=/usr/bin/cog-fdo-ctl reload
 
 [launcher]
+icon=/usr/share/24x24-blank.png
+displayname=Separator
+path=/usr/bin/false
+
+[launcher]
 icon=/usr/share/icons/Adwaita/24x24/actions/find-location-symbolic.symbolic.png
 displayname=System monitor
 path=/usr/bin/toggle-gallium-hud
 
 [launcher]
+icon=/usr/share/24x24-blank.png
+displayname=Separator
+path=/usr/bin/false
+
+[launcher]
 icon=/usr/share/icons/Adwaita/24x24/actions/application-exit-symbolic.symbolic.png
 displayname=Close browser
 path=/usr/bin/kill-demo
-

--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -9,6 +9,7 @@ SRC_URI += "file://weston.env \
             file://cog-demo-run \
             file://demo-wpe-website \
             file://demo-wpe-duckduckgo\
+            file://24x24-blank.png \
             file://wpe_white.jpg \
             file://weston-terminal-configure-network \
            "
@@ -29,6 +30,7 @@ FILES:${PN} += "\
     ${bindir}/cog-demo-run \
     ${bindir}/demo-wpe-website \
     ${bindir}/demo-wpe-duckduckgo \
+    ${datadir}/24x24-blank.png \
     ${datadir}/wpe_white.jpg \
     ${bindir}/weston-terminal-configure-network \
     "
@@ -38,6 +40,7 @@ do_install:append () {
     install -D -p -m0644 ${WORKDIR}/wayland-1.service ${D}${systemd_system_unitdir}/wayland-1.service
     install -D -p -m0644 ${WORKDIR}/wayland-1.path ${D}${systemd_system_unitdir}/wayland-1.path
 
+    install -D -p -m0644 ${WORKDIR}/24x24-blank.png ${D}${datadir}/24x24-blank.png
     install -D -p -m0644 ${WORKDIR}/wpe_white.jpg ${D}${datadir}/wpe_white.jpg
 
     install -Dm755 ${WORKDIR}/kill-demo ${D}/${bindir}/kill-demo


### PR DESCRIPTION
- Add "fake" launchers (blank icons and invoking "false" program) to achieve the actual separation between icons, because otherwise with touchscreens it's very easy to invoke the wrong icon.

  For this purpose, add 24x24 blank "icon" to act as separator between launchers in panel.

  This is a bit of a hack but the implementation of the panel in Weston is very crude, with hardcoded sizes and ad-hoc code for widgets of the panel like clocks, and all the implementation for the rest of the launches revolves around that.  It would take a very significant effort to improve the panel to achieve what we want (which, in the end, is simply to not invoke the wrong launcher), and maybe the Weston devels want to keep things simple anyway (there are other compositors with many more features).

- Switch clock to seconds

  Since there are cases in which screen or the browser seems to freeze, or pages fail to load resources for several seconds, it's handy to have the clock showing seconds to prove that the whole graphical environment is not frozen, and in that way it's possible to have a rough estimate about the actual number of seconds elapsed to load or show elements.