### PR TITLE
presets: Add clang to the SDK

### DIFF
--- a/conf/templates/template/presets/conf.conf
+++ b/conf/templates/template/presets/conf.conf
@@ -28,3 +28,12 @@ ACCEPT_FSL_EULA = "1"
 LICENSE_FLAGS_ACCEPTED="commercial"
 
 I_SWEAR_TO_MIGRATE_TO_PYTHON3 = "yes"
+
+
+# Clang based cross compiler is not included into the generated SDK using bitbake
+# meta-toolchain or bitbake -cpopulate_sdk <image> if clang is expected to be
+# part of SDK, add CLANGSDK = "1" in local.conf
+#
+# Ref: https://github.com/kraj/meta-clang#adding-clang-in-generated-sdk-toolchain
+CLANGSDK = "1"
+


### PR DESCRIPTION
Clang based cross compiler is not included into the generated SDK using bitbake meta-toolchain or bitbake -cpopulate_sdk <image> if clang is expected to be part of SDK, add CLANGSDK = 1 in local.conf

Ref: https://github.com/kraj/meta-clang#adding-clang-in-generated-sdk-toolchain