### PR TITLE
machine(raspberrypi3): Fix CMA issues when a fullHD page renders to 60FPS

### DIFF
--- a/conf/machine/raspberrypi3-64-mesa.conf
+++ b/conf/machine/raspberrypi3-64-mesa.conf
@@ -5,8 +5,8 @@ MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberryp
 MACHINE_FEATURES += "vc4graphics"
 
 GPU_MEM_256 = "128"
-GPU_MEM_512 = "196"
-GPU_MEM_1024 = "256"
+GPU_MEM_512 = "128"
+GPU_MEM_1024 = "128"
 DISABLE_OVERSCAN = "1"
 RPI_EXTRA_CONFIG = ' \n \
         hdmi_group=0 \n \

--- a/conf/machine/raspberrypi3-mesa.conf
+++ b/conf/machine/raspberrypi3-mesa.conf
@@ -5,8 +5,8 @@ MACHINEOVERRIDES =. "use-mainline-bsp:raspberrypi3:"
 MACHINE_FEATURES += "vc4graphics"
 
 GPU_MEM_256 = "128"
-GPU_MEM_512 = "196"
-GPU_MEM_1024 = "256"
+GPU_MEM_512 = "128"
+GPU_MEM_1024 = "128"
 DISABLE_OVERSCAN = "1"
 RPI_EXTRA_CONFIG = ' \n \
         hdmi_group=0 \n \

--- a/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,0 +1,2 @@
+CMDLINE_CMA:raspberrypi3 = "cma=700M"
+


### PR DESCRIPTION
We need tweak the CMA value for the raspberrypi3 to avoid errors due to no memory available in CMA.

This patch adjust also the memory dedicated to the GPU to 128MB.