### PR TITLE
weston: Set core.repaint-window to 16

### DIFF
--- a/recipes-graphics/wayland/files/weston.ini
+++ b/recipes-graphics/wayland/files/weston.ini
@@ -2,6 +2,33 @@
 require-input=false
 idle-time=0
 
+# Set the approximate length of the repaint window in milliseconds.
+# The repaint window is used to control and reduce the output
+# latency for clients. If the window is longer than the output refresh
+# period, the repaint will be done immediately when the previous
+# repaint finishes, not processing client requests in between. If the
+# repaint window is too short, the compositor may miss the target
+# vertical blank, increasing output latency.
+#
+# On some hardware and with some backends that run over a wayland
+# session, it may happen that the weston default repaint window
+# interval (7ms) is too low for WPE. That causes WPE to sometimes fail
+# to deliver the frame in time for the vsync, causing a low frame-rate.
+#
+# To see if you are affected by this, you can open this simple
+# benchmark of requestAnimationFrame() with WPE and check the value
+# you get on your board. If you are getting a value lower than 60FPS,
+# then an idea is try to modify the weston repaint-window value.
+#
+# Ref: https://github.com/Igalia/meta-webkit/wiki/PerformanceTips#tuning-weston-repaint-window
+#
+# The default value is 7 milliseconds (120fps).
+#
+# The allowed range is from -10 to 1000 milliseconds. Using a negative
+# value will force the compositor to always miss the target vblank.
+#
+repaint-window=16
+
 [screen-share]
 command=/usr/bin/weston --backend=rdp-backend.so --shell=fullscreen-shell.so --no-clients-resize
 


### PR DESCRIPTION
Set the approximate length of the repaint window in milliseconds. The repaint window is used to control and reduce the output latency for clients. If the window is longer than the output refresh period, the repaint will be done immediately when the previous repaint finishes, not processing client requests in between. If the repaint window is too short, the compositor may miss the target vertical blank, increasing output latency.

On some hardware and with some backends that run over a wayland session, it may happen that the weston default repaint window interval (7ms) is too low for WPE. That causes WPE to sometimes fail to deliver the frame in time for the vsync, causing a low frame-rate.

To see if you are affected by this, you can open this simple benchmark of requestAnimationFrame() with WPE and check the value you get on your board. If you are getting a value lower than 60FPS, then an idea is try to modify the weston repaint-window value.

Ref:
https://github.com/Igalia/meta-webkit/wiki/PerformanceTips#tuning-weston-repaint-window

The default value is 7 milliseconds (120fps).

The allowed range is from -10 to 1000 milliseconds. Using a negative value will force the compositor to always miss the target vblank.