### PR TITLE
ci: Add new workflows for testing builds across various platforms     

### DIFF
--- a/.github/workflows/test-build-nightly.yml
+++ b/.github/workflows/test-build-nightly.yml
@@ -1,0 +1,73 @@
+name: Build tests for nightly
+on:
+  schedule:
+    # Runs at 3:00 AM UTC every day
+    - cron: '0 3 * * *'
+
+jobs:
+  scarthgap-repo:
+    runs-on: [self-hosted, builder]
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/bitbake-repo
+        with:
+          repo_release: 'scarthgap'
+
+  build-raspberrypi-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['raspberrypi3-mesa', 'raspberrypi5']
+        wpe_vers: ['nightly']
+        yocto_rel: ['scarthgap']
+    continue-on-error: true
+    runs-on: [self-hosted, builder]
+    needs: scarthgap-repo
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bitbake-build
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          bitbake_source: 'poky-wayland layers.raspberrypi conf.wpe-${{ matrix.wpe_vers }} --update-config'
+          repo_release: ${{ matrix.yocto_rel }}
+
+  test-raspberrypi-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['raspberrypi3-mesa', 'raspberrypi5']
+        wpe_vers: ['nightly']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, podman]
+    permissions:
+      pull-requests: write
+    needs: build-raspberrypi-nightly
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/podman-robot
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          github_token: ${GITHUB_TOKEN}

--- a/.github/workflows/test-build-raspberrypi3-mesa-nightly-manually.yml
+++ b/.github/workflows/test-build-raspberrypi3-mesa-nightly-manually.yml
@@ -1,0 +1,68 @@
+name: Build tests raspberrypi3-mesa nightly manually
+on: workflow_dispatch
+
+jobs:
+  scarthgap-repo:
+    runs-on: [self-hosted, builder]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/bitbake-repo
+        with:
+          repo_release: 'scarthgap'
+
+  build-raspberrypi3-mesa-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['raspberrypi3-mesa']
+        wpe_vers: ['nightly']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, builder]
+    needs: scarthgap-repo
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bitbake-build
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          bitbake_source: 'poky-wayland layers.raspberrypi conf.wpe-${{ matrix.wpe_vers }} --update-config'
+          repo_release: ${{ matrix.yocto_rel }}
+
+  test-raspberrypi3-mesa-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['raspberrypi3-mesa']
+        wpe_vers: ['nightly']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, podman]
+    permissions:
+      pull-requests: write
+    needs: build-raspberrypi3-mesa-nightly
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/podman-robot
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          github_token: ${GITHUB_TOKEN}

--- a/.github/workflows/test-build-raspberrypi3-mesa-stable-manually.yml
+++ b/.github/workflows/test-build-raspberrypi3-mesa-stable-manually.yml
@@ -1,0 +1,68 @@
+name: Build tests raspberrypi3-mesa stable manually
+on: workflow_dispatch
+
+jobs:
+  scarthgap-repo:
+    runs-on: [self-hosted, builder]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/bitbake-repo
+        with:
+          repo_release: 'scarthgap'
+
+  build-raspberrypi3-mesa-stable:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['raspberrypi3-mesa']
+        wpe_vers: ['2_46']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, builder]
+    needs: scarthgap-repo
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bitbake-build
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          bitbake_source: 'poky-wayland layers.raspberrypi conf.wpe-${{ matrix.wpe_vers }} --update-config'
+          repo_release: ${{ matrix.yocto_rel }}
+
+  test-raspberrypi3-mesa-stable:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['raspberrypi3-mesa']
+        wpe_vers: ['2_46']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, podman]
+    permissions:
+      pull-requests: write
+    needs: build-raspberrypi3-mesa-stable
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/podman-robot
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          github_token: ${GITHUB_TOKEN}

--- a/.github/workflows/test-build-raspberrypi5-nightly-manually.yml
+++ b/.github/workflows/test-build-raspberrypi5-nightly-manually.yml
@@ -1,0 +1,69 @@
+name: Build tests raspberrypi5 nightly manually
+on: workflow_dispatch
+
+jobs:
+  scarthgap-repo:
+    runs-on: [self-hosted, builder]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/bitbake-repo
+        with:
+          repo_release: 'scarthgap'
+
+  build-raspberrypi5-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['raspberrypi5']
+        wpe_vers: ['nightly']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, builder]
+    needs: scarthgap-repo
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bitbake-build
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          bitbake_source: 'poky-wayland layers.raspberrypi conf.wpe-${{ matrix.wpe_vers }} --update-config'
+          repo_release: ${{ matrix.yocto_rel }}
+
+  test-raspberrypi5-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['raspberrypi5']
+        wpe_vers: ['nightly']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, podman]
+    permissions:
+      pull-requests: write
+    needs: build-raspberrypi5-nightly
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/podman-robot
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          github_token: ${GITHUB_TOKEN}
+

--- a/.github/workflows/test-build-raspberrypi5-stable-manually.yml
+++ b/.github/workflows/test-build-raspberrypi5-stable-manually.yml
@@ -1,0 +1,69 @@
+name: Build tests raspberrypi5 stable manually
+on: workflow_dispatch
+
+jobs:
+  scarthgap-repo:
+    runs-on: [self-hosted, builder]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/bitbake-repo
+        with:
+          repo_release: 'scarthgap'
+
+  build-raspberrypi5-stable:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['raspberrypi5']
+        wpe_vers: ['2_46']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, builder]
+    needs: scarthgap-repo
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bitbake-build
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          bitbake_source: 'poky-wayland layers.raspberrypi conf.wpe-${{ matrix.wpe_vers }} --update-config'
+          repo_release: ${{ matrix.yocto_rel }}
+
+  test-raspberrypi5-stable:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['raspberrypi5']
+        wpe_vers: ['2_46']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, podman]
+    permissions:
+      pull-requests: write
+    needs: build-raspberrypi5-stable
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/podman-robot
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          github_token: ${GITHUB_TOKEN}
+

--- a/.github/workflows/test-build-wandboard-mesa-nightly-manually.yml
+++ b/.github/workflows/test-build-wandboard-mesa-nightly-manually.yml
@@ -1,0 +1,68 @@
+name: Build tests wandboard-mesa nightly manually
+on: workflow_dispatch
+
+jobs:
+  scarthgap-repo:
+    runs-on: [self-hosted, builder]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/bitbake-repo
+        with:
+          repo_release: 'scarthgap'
+
+  build-wandboard-mesa-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['wandboard-mesa']
+        wpe_vers: ['nightly']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, builder]
+    needs: scarthgap-repo
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bitbake-build
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          bitbake_source: 'poky-wayland layers.raspberrypi conf.wpe-${{ matrix.wpe_vers }} --update-config'
+          repo_release: ${{ matrix.yocto_rel }}
+
+  test-wandboard-mesa-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['wandboard-mesa']
+        wpe_vers: ['nightly']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, podman]
+    permissions:
+      pull-requests: write
+    needs: build-wandboard-mesa-nightly
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/podman-robot
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          github_token: ${GITHUB_TOKEN}

--- a/.github/workflows/test-build-wandboard-mesa-stable-manually.yml
+++ b/.github/workflows/test-build-wandboard-mesa-stable-manually.yml
@@ -1,0 +1,68 @@
+name: Build tests wandboard-mesa stable manually
+on: workflow_dispatch
+
+jobs:
+  scarthgap-repo:
+    runs-on: [self-hosted, builder]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/bitbake-repo
+        with:
+          repo_release: 'scarthgap'
+
+  build-wandboard-mesa-stable:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['wandboard-mesa']
+        wpe_vers: ['2_46']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, builder]
+    needs: scarthgap-repo
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bitbake-build
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          bitbake_source: 'poky-wayland layers.raspberrypi conf.wpe-${{ matrix.wpe_vers }} --update-config'
+          repo_release: ${{ matrix.yocto_rel }}
+
+  test-wandboard-mesa-stable:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['wandboard-mesa']
+        wpe_vers: ['2_46']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, podman]
+    permissions:
+      pull-requests: write
+    needs: build-wandboard-mesa-stable
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/podman-robot
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          github_token: ${GITHUB_TOKEN}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,4 +1,4 @@
-name: Build tests
+name: Build tests Pull Request
 on: [pull_request]
 jobs:
   scarthgap-repo:
@@ -19,15 +19,14 @@ jobs:
         with:
           repo_release: 'scarthgap'
 
-  build-raspberrypi-stable:
+  build-raspberrypi5-stable:
     strategy:
       fail-fast: false
       matrix:
-        machine: ['raspberrypi3-mesa', 'raspberrypi4-64-mesa', 'raspberrypi5']
+        machine: ['raspberrypi5']
         wpe_vers: ['2_46']
         yocto_rel: ['scarthgap']
     runs-on: [self-hosted, builder]
-    if: "!contains(github.event.head_commit.message, 'ci skip') && github.event_name == 'pull_request'"
     needs: scarthgap-repo
     steps:
       - uses: actions/checkout@v3
@@ -38,17 +37,17 @@ jobs:
           bitbake_source: 'poky-wayland layers.raspberrypi conf.wpe-${{ matrix.wpe_vers }} --update-config'
           repo_release: ${{ matrix.yocto_rel }}
 
-  test-raspberrypi-stable:
+  test-raspberrypi5-stable:
     strategy:
       fail-fast: false
       matrix:
-        machine: ['raspberrypi3-mesa', 'raspberrypi5']
+        machine: ['raspberrypi5']
         wpe_vers: ['2_46']
         yocto_rel: ['scarthgap']
     runs-on: [self-hosted, podman]
     permissions:
       pull-requests: write
-    needs: build-raspberrypi-stable
+    needs: build-raspberrypi5-stable
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/s3-configure
@@ -68,14 +67,13 @@ jobs:
           bitbake_machine: ${{ matrix.machine }}
           github_token: ${GITHUB_TOKEN}
 
-  build-raspberrypi-nightly:
+  build-raspberrypi-rest-stable:
     strategy:
       fail-fast: false
       matrix:
-        machine: ['raspberrypi3-mesa', 'raspberrypi4-64-mesa', 'raspberrypi5']
-        wpe_vers: ['nightly']
+        machine: ['raspberrypi3-mesa', 'raspberrypi4-64-mesa']
+        wpe_vers: ['2_46']
         yocto_rel: ['scarthgap']
-    continue-on-error: true
     runs-on: [self-hosted, builder]
     if: "!contains(github.event.head_commit.message, 'ci skip') && github.event_name == 'pull_request' && !github.event.pull_request.draft"
     needs: scarthgap-repo
@@ -88,12 +86,42 @@ jobs:
           bitbake_source: 'poky-wayland layers.raspberrypi conf.wpe-${{ matrix.wpe_vers }} --update-config'
           repo_release: ${{ matrix.yocto_rel }}
 
-  build-freescale:
+  test-raspberrypi-rest-stable:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['raspberrypi3-mesa']
+        wpe_vers: ['2_46']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, podman]
+    permissions:
+      pull-requests: write
+    needs: build-raspberrypi-rest-stable
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/podman-robot
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          github_token: ${GITHUB_TOKEN}
+
+  build-freescale-stable:
     strategy:
       fail-fast: false
       matrix:
         machine: ['wandboard-mesa']
-        wpe_vers: ['2_46', 'nightly']
+        wpe_vers: ['2_46']
         yocto_rel: ['scarthgap']
     continue-on-error: true
     runs-on: [self-hosted, builder]
@@ -108,3 +136,32 @@ jobs:
           bitbake_source: 'poky-wayland layers.freescale conf.wpe-${{ matrix.wpe_vers }} --update-config'
           repo_release: ${{ matrix.yocto_rel }}
 
+  test-freescale-stable:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ['wandboard-mesa']
+        wpe_vers: ['2_46']
+        yocto_rel: ['scarthgap']
+    runs-on: [self-hosted, podman]
+    permissions:
+      pull-requests: write
+    needs: build-freescale-stable
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/s3-configure
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+          S3_HOST_BASE: ${{ secrets.S3_HOST_BASE }}
+        with:
+          access_key: ${S3_ACCESS_KEY}
+          secret_key: ${S3_SECRET_KEY}
+          host_base: ${S3_HOST_BASE}
+      - uses: ./.github/actions/podman-robot
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
+          bitbake_machine: ${{ matrix.machine }}
+          github_token: ${GITHUB_TOKEN}


### PR DESCRIPTION
* Added nightly and manual workflows for Raspberry Pi 3 Mesa, Raspberry Pi 5, and Wandboard Mesa for stable and nightly builds.
* Updated pull request workflow to separate builds and tests for   Raspberry Pi 5 and other devices.
* Introduced specific workflows for Freescale platforms with stable builds.
