### PR TITLE
ci: Add commit message sanitizer and enhance BitBake repo action  

### DIFF
--- a/.github/actions/bitbake-repo/action.yml
+++ b/.github/actions/bitbake-repo/action.yml
@@ -30,7 +30,17 @@ runs:
         mkdir -p ~/yocto-meta-wpe-image-${{ inputs.repo_release }}
         cd ~/yocto-meta-wpe-image-${{ inputs.repo_release }}
         repo init -u ${{ inputs.repo_url }} -m manifest-${{ inputs.repo_release }}.xml -b ${{ inputs.repo_ref }}
-        repo sync --force-sync
+
+        attempt=0
+        until repo sync --force-sync; do
+          attempt=$((attempt+1))
+          if [ $attempt -ge 5 ]; then
+            echo "repo sync failed after 5 attempts. Exiting."
+            exit 1
+          fi
+          echo "repo sync failed. Retrying in 30 seconds... ($attempt/5)"
+          sleep 30
+        done
 
         pushd sources/meta-wpe-image
         git config --global user.email "meta-wpe-image-bot@igalia.com"

--- a/.github/scripts/sanatizer-git-commit-messages
+++ b/.github/scripts/sanatizer-git-commit-messages
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+echo "Running git commit log messages check:"
+
+error_found=0
+
+baseref="main"
+headref="HEAD"
+
+git fetch origin $baseref 2>&1 > /dev/null
+
+if [[ -n "${GITHUB_HEAD_REF}" ]]; then
+    headref="origin/${GITHUB_HEAD_REF}"
+    git fetch origin ${GITHUB_HEAD_REF} 2>&1 > /dev/null
+fi
+
+# Get commit messages
+commits=$(git log origin/${baseref}..${headref} --pretty=format:"%s")
+echo "$commits" > commit_messages.txt
+
+# Check commit messages format
+while IFS= read -r line; do
+  if ! [[ $line =~ ^[a-zA-Z]+:\ [a-zA-Z]+ ]]; then
+    echo "Invalid commit message: $line"
+    error_found=1
+  fi
+done < commit_messages.txt
+
+# Get full commit messages
+commits=$(git log origin/${baseref}..${headref} --pretty=format:"%B")
+echo "$commits" > commit_messages.txt
+
+# Check for required keywords
+if ! grep -qE 'Change-type:|Maintenance-type:' commit_messages.txt; then
+    echo "Error: No commit message contains 'Change-type:' or 'Maintenance-type:'."
+    error_found=1
+fi
+
+rm commit_messages.txt
+# Exit with the appropriate status
+exit $error_found


### PR DESCRIPTION
This PR introduces improvements to the CI pipeline:  

- Added `sanitizer-git-commit-messages` script to enforce commit message formatting standards.  
  - Ensures commit messages start with a capitalized word followed by a colon and a space.  
  - Verifies the presence of `Change-type:` or `Maintenance-type:` keywords.  
- Enhanced `bitbake-repo/action.yml` by adding retry logic to the `repo sync` command for better reliability.  

