### PR TITLE
ci: Ensure Git LFS Files are Pulled in Podman Robot Action

### DIFF
--- a/.github/actions/podman-robot/action.yml
+++ b/.github/actions/podman-robot/action.yml
@@ -44,6 +44,7 @@ runs:
     - name: Prepare the Robot-Framework related PODs in background
       shell: bash
       run:  |
+        git lfs pull
         pushd .ci
         podman rm ci_webserver_1 ci_robot_1 -f
         ./podman-compose.sh up --force-recreate --always-recreate-deps --build -d


### PR DESCRIPTION
Added `git lfs pull` command to the `podman-robot/action.yml` to ensure all LFS files are downloaded before starting the Robot-Framework related PODs.

Maintenance-Type: ci