### PR TITLE
Enable Polkit and Sysprof Support in Poky-Wayland and WPEWebKit, Upgrade Sysprof to 47.2  

### DIFF
--- a/conf/distro/poky-wayland.conf
+++ b/conf/distro/poky-wayland.conf
@@ -11,6 +11,7 @@ DISTROOVERRIDES = "poky:poky-altcfg:linuxstdbase"
 DISTRO_FEATURES:append = " egl \
                            opengl \
                            pam \
+                           polkit \
                            pulseaudio \
                            virtualization \
                            wayland \

--- a/conf/templates/template/bblayers/bblayers.conf.layers
+++ b/conf/templates/template/bblayers/bblayers.conf.layers
@@ -9,6 +9,7 @@ BBLAYERS = " \
   ${BSPDIR}/sources/poky/meta-poky \
   \
   ${BSPDIR}/sources/meta-openembedded/meta-oe \
+  ${BSPDIR}/sources/meta-openembedded/meta-gnome \
   ${BSPDIR}/sources/meta-openembedded/meta-multimedia \
   ${BSPDIR}/sources/meta-openembedded/meta-perl \
   ${BSPDIR}/sources/meta-openembedded/meta-python \

--- a/recipes-browser/wpewebkit/wpewebkit_2.46.%.bbappend
+++ b/recipes-browser/wpewebkit/wpewebkit_2.46.%.bbappend
@@ -11,6 +11,8 @@ PV:class-devupstream = "trunk"
 
 RCONFLICTS:${PN}:class-devupstream = ""
 
+PACKAGECONFIG[sysprof] = "-DUSE_SYSTEM_SYSPROF_CAPTURE=ON, -DUSE_SYSTEM_SYSPROF_CAPTURE=OFF,"
+
 PACKAGECONFIG:append = " experimental-wpe-platform lbse offscreen-canvas"
 PACKAGECONFIG:remove = "speech-synthesis"
 

--- a/recipes-core/images/core-image-weston-wpe.bb
+++ b/recipes-core/images/core-image-weston-wpe.bb
@@ -6,6 +6,7 @@ IMAGE_INSTALL:append = " \
     wpewebkit \
     wpe-simple-launcher \
     python3-uinput \
+    sysprof \
 "
 
 IMAGE_INSTALL:append:raspberrypi4 = " rpi-eeprom"

--- a/recipes-gnome/libdex/libdex_0.8.1.bb
+++ b/recipes-gnome/libdex/libdex_0.8.1.bb
@@ -1,0 +1,19 @@
+LICENSE = "LGPL-2.1-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
+
+GNOMEBASEBUILDCLASS = "meson"
+inherit features_check gnomebase upstream-version-is-even gobject-introspection
+
+DEPENDS += " \
+    glib-2.0 \
+"
+DEPENDS:append:libc-musl = " libucontext"
+
+LDFLAGS:append:libc-musl = " -lucontext"
+
+SRC_URI[archive.sha256sum] = "955475ad3e43aabd6f6f70435264b5ee77bd265bd95545211fee026b08d378a0"
+
+PACKAGECONFIG ?= ""
+EXTRA_OEMESON += "-Dintrospection=enabled -Dvapi=false"
+
+REQUIRED_DISTRO_FEATURES = "gobject-introspection-data"

--- a/recipes-gnome/libpanel/libpanel_1.6.0.bb
+++ b/recipes-gnome/libpanel/libpanel_1.6.0.bb
@@ -1,0 +1,22 @@
+# your responsibility to verify that the values are complete and correct.
+LICENSE = "LGPL-2.1-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=3000208d539ec061b899bce1d9ce9404"
+
+GNOMEBASEBUILDCLASS = "meson"
+inherit gnomebase upstream-version-is-even gobject-introspection gtk-icon-cache
+
+DEPENDS += " \
+    glib-2.0 \
+    gtk4 \
+    libadwaita \
+"
+
+SRC_URI[archive.sha256sum] = "b773494a3c69300345cd8e27027448d1189183026cc137802f886417c6ea30b6"
+
+PACKAGECONFIG ?= ""
+#EXTRA_OEMESON += "-Ddocs=disabled"
+#GTKDOC_MESON_DISABLE_FLAG = "disabled"
+
+EXTRA_OEMESON += "-Ddocs=disabled  -Dintrospection=enabled -Dvapi=false"
+
+REQUIRED_DISTRO_FEATURES = "gobject-introspection-data"

--- a/recipes-gnome/sysprof/sysprof/0001-Turn-polkit-agent-support-into-an-optional-feature.patch
+++ b/recipes-gnome/sysprof/sysprof/0001-Turn-polkit-agent-support-into-an-optional-feature.patch
@@ -1,0 +1,155 @@
+From 1d892e44b11368549b1a4c83a4881c94f5b82be1 Mon Sep 17 00:00:00 2001
+From: Nikolas Zimmermann <nzimmermann@igalia.com>
+Date: Tue, 20 Aug 2024 20:46:11 +0200
+Subject: [PATCH] Turn polkit-agent support into an optional feature.
+
+This simplifies deployment on embedded devices, where polkit is usually
+unncessary at runtime, but pulls in quite a few otherwise unncessary
+dependencies. Start to improve the situation by allowing to selectively
+disable polkit-agent support at compile time, which aids in container
+usage scenarios, where one wants to invoke 'sysprof-cli' from within
+the container. Bypassing polkit-agent in the container is then desired,
+since the host sysprofd will handle asking for permissions to enable
+the tracing. It allows for a simpler setup of rootless podman
+containers, avoiding UID mismatches, that lead to rejection of the
+tracing enablement.
+
+- Add a new 'polkit-agent' meson build feature, that allows to force disabling
+  polkit-agent support (-Dpolkit-agent=disabled).
+
+- Mark the 'polkit-agent' feature as enabled, by default, to reflect
+  the current status (sysprof-cli did not build without polkit-agent support).
+
+- libsysprof/sysprof-instrument.c: Build fix when polkit is not available,
+  remove the unnecessary 'g_autopr(PolkitDetails) details' variable.
+
+- Alter the sysprof-cli dependencies to only attempt to link against
+  polkit-agent, if necessary. Modify sysprof-cli.c to wrap all code using
+  polkit-agent in HAVE_POLKIT_AGENT blocks.
+
+Upstream-Status: Backport [https://gitlab.gnome.org/GNOME/sysprof/-/merge_requests/100]
+---
+ meson.build                         |  2 +-
+ meson_options.txt                   |  6 ++++++
+ src/libsysprof/sysprof-instrument.c |  3 +--
+ src/sysprof-cli/meson.build         |  6 ++++--
+ src/sysprof-cli/sysprof-cli.c       | 12 +++++++++---
+ 5 files changed, 21 insertions(+), 8 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 70d88f2..69475b0 100644
+--- a/meson.build
++++ b/meson.build
+@@ -100,7 +100,7 @@ config_h.set_quoted('GETTEXT_PACKAGE', 'sysprof')
+ config_h.set_quoted('PACKAGE_LOCALE_DIR', join_paths(get_option('prefix'), get_option('datadir'), 'locale'))
+ config_h.set10('HAVE_LIBSYSTEMD', libsystemd_dep.found())
+ 
+-polkit_agent_dep = dependency('polkit-agent-1', required: false)
++polkit_agent_dep = dependency('polkit-agent-1', required: get_option('polkit-agent'))
+ config_h.set10('HAVE_POLKIT_AGENT', polkit_agent_dep.found())
+ 
+ polkit_dep = dependency('polkit-gobject-1', version: polkit_req_version, required: false)
+diff --git a/meson_options.txt b/meson_options.txt
+index 6abda00..2f78fc3 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -11,6 +11,12 @@ option('gtk', type: 'boolean')
+ # Allow disabling the installation of libsysprof-capture*.a
+ option('install-static', type: 'boolean')
+ 
++# Allow disabling of features that depend on polkit-agent.
++option('polkit-agent', type: 'feature',
++  value: 'auto',
++  description: 'Enable features which require polkit-agent-1'
++)
++
+ # Optionally compile sysprofd, which is needed to get elevated privileges.
+ # You only really want to ignore this if you are running from a container
+ # and are talking to a host daemon. Also, if you're compiling for something
+diff --git a/src/libsysprof/sysprof-instrument.c b/src/libsysprof/sysprof-instrument.c
+index 404d78f..f44c35f 100644
+--- a/src/libsysprof/sysprof-instrument.c
++++ b/src/libsysprof/sysprof-instrument.c
+@@ -178,7 +178,6 @@ _sysprof_instruments_acquire_policy (GPtrArray        *instruments,
+                                      SysprofRecording *recording)
+ {
+   g_autoptr(GDBusConnection) connection = NULL;
+-  g_autoptr(PolkitDetails) details = NULL;
+   g_autoptr(GError) error = NULL;
+   g_auto(GStrv) required_policy = NULL;
+ 
+@@ -202,7 +201,7 @@ _sysprof_instruments_acquire_policy (GPtrArray        *instruments,
+         {
+           if (!dex_await_boolean (_sysprof_polkit_authorize (connection,
+                                                              required_policy[i],
+-                                                             details,
++                                                             NULL,
+                                                              TRUE), &error))
+             return dex_future_new_for_error (g_steal_pointer (&error));
+         }
+diff --git a/src/sysprof-cli/meson.build b/src/sysprof-cli/meson.build
+index a6ea83e..abf2a60 100644
+--- a/src/sysprof-cli/meson.build
++++ b/src/sysprof-cli/meson.build
+@@ -6,11 +6,13 @@ sysprof_cli_c_args = [
+ ]
+ 
+ sysprof_cli_deps = [
+-  dependency('polkit-agent-1'),
+-
+   libsysprof_static_dep,
+ ]
+ 
++if polkit_agent_dep.found()
++  sysprof_cli_deps += polkit_agent_dep
++endif
++
+ sysprof_cli = executable('sysprof-cli', sysprof_cli_sources,
+   dependencies: sysprof_cli_deps,
+         c_args: release_flags + sysprof_cli_c_args,
+diff --git a/src/sysprof-cli/sysprof-cli.c b/src/sysprof-cli/sysprof-cli.c
+index 1fd274f..bfca951 100644
+--- a/src/sysprof-cli/sysprof-cli.c
++++ b/src/sysprof-cli/sysprof-cli.c
+@@ -32,9 +32,11 @@
+ 
+ #include <sysprof.h>
+ 
+-#define POLKIT_AGENT_I_KNOW_API_IS_SUBJECT_TO_CHANGE
+-#include <polkit/polkit.h>
+-#include <polkitagent/polkitagent.h>
++#if HAVE_POLKIT_AGENT
++# define POLKIT_AGENT_I_KNOW_API_IS_SUBJECT_TO_CHANGE
++# include <polkit/polkit.h>
++# include <polkitagent/polkitagent.h>
++#endif
+ 
+ #include "sysprof-capture-util-private.h"
+ 
+@@ -266,8 +268,10 @@ int
+ main (int   argc,
+       char *argv[])
+ {
++#if HAVE_POLKIT_AGENT
+   PolkitAgentListener *polkit = NULL;
+   PolkitSubject *subject = NULL;
++#endif
+   g_autoptr(SysprofCaptureWriter) writer = NULL;
+   g_autoptr(SysprofProfiler) profiler = NULL;
+   g_autofree char *power_profile = NULL;
+@@ -413,6 +417,7 @@ Examples:\n\
+ 
+   main_loop = g_main_loop_new (NULL, FALSE);
+ 
++#if HAVE_POLKIT_AGENT
+   /* Start polkit agent so that we can elevate privileges from a TTY */
+   if (g_getenv ("DESKTOP_SESSION") == NULL &&
+       (subject = polkit_unix_process_new_for_owner (getpid (), 0, -1)))
+@@ -434,6 +439,7 @@ Examples:\n\
+                       pkerror->message);
+         }
+     }
++#endif
+ 
+   /* Warn about access if we're in a container */
+   if (g_file_test ("/.flatpak-info", G_FILE_TEST_EXISTS))

--- a/recipes-gnome/sysprof/sysprof/0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch
+++ b/recipes-gnome/sysprof/sysprof/0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch
@@ -1,0 +1,32 @@
+From 779bbfebcd414a2cb4ab73ff1c4eb987cfdab456 Mon Sep 17 00:00:00 2001
+From: Pablo Saavedra <psaavedra@igalia.com>
+Date: Mon, 11 Nov 2024 13:05:15 +0100
+Subject: [PATCH] meson: Check for libunwind instead of libunwind-generic
+
+This helps it to use llvm unwinder since libunwind-generic is specific
+to nongnu libunwind.
+
+Upstream-Status: Submitted [https://gitlab.gnome.org/GNOME/sysprof/-/merge_requests/95]
+
+Original-by: Khem Raj <raj.khem@gmail.com>
+Modified-by: Pablo Saavedra <psaavedra@igalia.com>
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 96c1d09..86b9df4 100644
+--- a/meson.build
++++ b/meson.build
+@@ -107,7 +107,7 @@ polkit_dep = dependency('polkit-gobject-1', version: polkit_req_version, require
+ config_h.set10('HAVE_POLKIT', polkit_dep.found())
+ 
+ if need_libsysprof
+-  libunwind_dep = dependency('libunwind-generic', required: true)
++  libunwind_dep = dependency('libunwind', required: true)
+   config_h.set('ENABLE_LIBUNWIND', libunwind_dep.found())
+   config_h.set('HAVE_UNW_SET_CACHE_SIZE',
+                cc.has_header_symbol('libunwind.h',

--- a/recipes-gnome/sysprof/sysprof/0002-Make-PolKit-usage-a-build-time-option.patch
+++ b/recipes-gnome/sysprof/sysprof/0002-Make-PolKit-usage-a-build-time-option.patch
@@ -1,0 +1,154 @@
+From 2d48084e136ca515737515918ebd0cff291dc144 Mon Sep 17 00:00:00 2001
+From: Adrian Perez de Castro <aperez@igalia.com>
+Date: Wed, 28 Aug 2024 15:07:36 +0300
+Subject: [PATCH] Make PolKit usage a build-time option
+
+Allow compiling without PolKit to gain elevated privileges to start
+the RAPL profiler (by means of turbostat) and instruct sysprofd to
+start gathering profiling data. Using these features should be still
+possible by running e.g. sysprof-cli as root, or allowing other users
+in the bus configuration XML.
+
+Disabling PolKit is more likely to be used in embedded systems, in
+which case it seems reasonable to have less build dependencies, and
+assume that either integrators would be able to either customize the
+bus configuration, or use Sysprof only in development builds where
+running as root may be acceptable.
+
+Upstream-Status: Submitted [https://gitlab.gnome.org/GNOME/sysprof/-/merge_requests/103]
+---
+ meson.build                      | 12 ++++++++----
+ meson_options.txt                |  6 ++++++
+ src/sysprofd/ipc-rapl-profiler.c |  9 +++++++--
+ src/sysprofd/ipc-service-impl.c  |  6 ++++++
+ 4 files changed, 27 insertions(+), 6 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 69475b0..b7461ca 100644
+--- a/meson.build
++++ b/meson.build
+@@ -100,12 +100,16 @@ config_h.set_quoted('GETTEXT_PACKAGE', 'sysprof')
+ config_h.set_quoted('PACKAGE_LOCALE_DIR', join_paths(get_option('prefix'), get_option('datadir'), 'locale'))
+ config_h.set10('HAVE_LIBSYSTEMD', libsystemd_dep.found())
+ 
+-polkit_agent_dep = dependency('polkit-agent-1', required: get_option('polkit-agent'))
+-config_h.set10('HAVE_POLKIT_AGENT', polkit_agent_dep.found())
+-
+-polkit_dep = dependency('polkit-gobject-1', version: polkit_req_version, required: false)
++polkit_dep = dependency('polkit-gobject-1', version: polkit_req_version, required: get_option('polkit'))
+ config_h.set10('HAVE_POLKIT', polkit_dep.found())
+ 
++if polkit_dep.found()
++  polkit_agent_dep = dependency('polkit-agent-1', required: get_option('polkit-agent'))
++else
++  polkit_agent_dep = disabler()
++endif
++config_h.set10('HAVE_POLKIT_AGENT', polkit_agent_dep.found())
++
+ if need_libsysprof
+   libunwind_dep = dependency('libunwind', required: true)
+   config_h.set('ENABLE_LIBUNWIND', libunwind_dep.found())
+diff --git a/meson_options.txt b/meson_options.txt
+index 2f78fc3..f1d766e 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -11,6 +11,12 @@ option('gtk', type: 'boolean')
+ # Allow disabling the installation of libsysprof-capture*.a
+ option('install-static', type: 'boolean')
+ 
++# Allow disabling of features that depend on polkit.
++option('polkit', type: 'feature',
++  value: 'auto',
++  description: 'Enable features which require polkit'
++)
++
+ # Allow disabling of features that depend on polkit-agent.
+ option('polkit-agent', type: 'feature',
+   value: 'auto',
+diff --git a/src/sysprofd/ipc-rapl-profiler.c b/src/sysprofd/ipc-rapl-profiler.c
+index 9b91847..93791d1 100644
+--- a/src/sysprofd/ipc-rapl-profiler.c
++++ b/src/sysprofd/ipc-rapl-profiler.c
+@@ -25,7 +25,9 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <gio/gunixfdlist.h>
++#if HAVE_POLKIT
+ #include <polkit/polkit.h>
++#endif
+ #include <sysprof-capture.h>
+ #include <unistd.h>
+ 
+@@ -177,6 +179,7 @@ get_counter_base (SysprofCaptureWriter *writer,
+   return add_counter_base (writer, counters, core, cpu);
+ }
+ 
++#if HAVE_POLKIT
+ static gboolean
+ ipc_rapl_profiler_g_authorize_method (GDBusInterfaceSkeleton *skeleton,
+                                       GDBusMethodInvocation  *invocation)
+@@ -218,6 +221,7 @@ ipc_rapl_profiler_g_authorize_method (GDBusInterfaceSkeleton *skeleton,
+ 
+   return ret;
+ }
++#endif
+ 
+ static void
+ ipc_rapl_profiler_finalize (GObject *object)
+@@ -234,11 +238,12 @@ static void
+ ipc_rapl_profiler_class_init (IpcRaplProfilerClass *klass)
+ {
+   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+-  GDBusInterfaceSkeletonClass *skeleton_class = G_DBUS_INTERFACE_SKELETON_CLASS (klass);
+-
+   object_class->finalize = ipc_rapl_profiler_finalize;
+ 
++#if HAVE_POLKIT
++  GDBusInterfaceSkeletonClass *skeleton_class = G_DBUS_INTERFACE_SKELETON_CLASS (klass);
+   skeleton_class->g_authorize_method = ipc_rapl_profiler_g_authorize_method;
++#endif
+ 
+   /**
+    * IpcRaplProfiler::activity:
+diff --git a/src/sysprofd/ipc-service-impl.c b/src/sysprofd/ipc-service-impl.c
+index 50825cf..f1c1205 100644
+--- a/src/sysprofd/ipc-service-impl.c
++++ b/src/sysprofd/ipc-service-impl.c
+@@ -25,7 +25,9 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <gio/gunixfdlist.h>
++#if HAVE_POLKIT
+ #include <polkit/polkit.h>
++#endif
+ #include <string.h>
+ #include <sys/syscall.h>
+ #include <time.h>
+@@ -255,6 +257,7 @@ ipc_service_impl_handle_perf_event_open (IpcService            *service,
+   return TRUE;
+ }
+ 
++#if HAVE_POLKIT
+ static gboolean
+ ipc_service_impl_g_authorize_method (GDBusInterfaceSkeleton *skeleton,
+                                      GDBusMethodInvocation  *invocation)
+@@ -296,6 +299,7 @@ ipc_service_impl_g_authorize_method (GDBusInterfaceSkeleton *skeleton,
+ 
+   return ret;
+ }
++#endif
+ 
+ static gboolean
+ ipc_service_impl_handle_get_process_info (IpcService            *service,
+@@ -440,9 +444,11 @@ G_DEFINE_TYPE_WITH_CODE (IpcServiceImpl, ipc_service_impl, IPC_TYPE_SERVICE_SKEL
+ static void
+ ipc_service_impl_class_init (IpcServiceImplClass *klass)
+ {
++#if HAVE_POLKIT
+   GDBusInterfaceSkeletonClass *skeleton_class = G_DBUS_INTERFACE_SKELETON_CLASS (klass);
+ 
+   skeleton_class->g_authorize_method = ipc_service_impl_g_authorize_method;
++#endif
+ 
+   signals [ACTIVITY] =
+     g_signal_new ("activity",

--- a/recipes-gnome/sysprof/sysprof/0002-meson-Do-not-invoke-the-commands-to-update-the-icon-.patch
+++ b/recipes-gnome/sysprof/sysprof/0002-meson-Do-not-invoke-the-commands-to-update-the-icon-.patch
@@ -1,0 +1,29 @@
+From cc0c0b518d46bf82ad34eeea8d40496c9ad971dd Mon Sep 17 00:00:00 2001
+From: Carlos Alberto Lopez Perez <clopez@igalia.com>
+Date: Wed, 24 Jul 2024 15:51:05 +0100
+Subject: [PATCH] meson: Do not invoke the commands to update the icon caches
+ when cross-building
+
+This does not have any useful efect when cross-building and it requires
+the cross-builder environment to have gtk4-native built in order to invoke
+gtk-update-icon-cache program.
+
+Upstream-Status: Pending
+Signed-off-by: Carlos Alberto Lopez Perez <clopez@igalia.com>
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 86b9df4..fe75ef9 100644
+--- a/meson.build
++++ b/meson.build
+@@ -269,7 +269,7 @@ configure_file(
+   configuration: config_h
+ )
+ 
+-if get_option('gtk') and gnome.found()
++if get_option('gtk') and gnome.found() and not meson.is_cross_build()
+   gnome.post_install(
+       gtk_update_icon_cache: true,
+     update_desktop_database: true

--- a/recipes-gnome/sysprof/sysprof/0003-libsysprof-Check-for-unw_set_caching_policy-before-u.patch
+++ b/recipes-gnome/sysprof/sysprof/0003-libsysprof-Check-for-unw_set_caching_policy-before-u.patch
@@ -1,0 +1,32 @@
+From 68425b541e88f9f03a418cfda052b46b2a185e4e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 25 Jul 2024 20:18:17 -0700
+Subject: [PATCH] libsysprof: Check for unw_set_caching_policy before using
+
+llvm libunwind does not implement unw_cache_* functions yet
+
+Upstream-Status: Submitted [https://gitlab.gnome.org/GNOME/sysprof/-/merge_requests/95]
+
+Original-by: Khem Raj <raj.khem@gmail.com>
+Modified-by: Pablo Saavedra <psaavedra@igalia.com>
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>
+---
+ src/preload/backtrace-helper.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/preload/backtrace-helper.h b/src/preload/backtrace-helper.h
+index ac4f8e9..e60032d 100644
+--- a/src/preload/backtrace-helper.h
++++ b/src/preload/backtrace-helper.h
+@@ -26,7 +26,9 @@
+ static void
+ backtrace_init (void)
+ {
++# ifdef UNW_CACHE_PER_THREAD
+   unw_set_caching_policy (unw_local_addr_space, UNW_CACHE_PER_THREAD);
++#endif
+ #ifdef HAVE_UNW_SET_CACHE_SIZE
+   unw_set_cache_size (unw_local_addr_space, 1024, 0);
+ #endif

--- a/recipes-gnome/sysprof/sysprof/0003-sysprofd-Check-that-remote-user-is-root-when-PolKit-.patch
+++ b/recipes-gnome/sysprof/sysprof/0003-sysprofd-Check-that-remote-user-is-root-when-PolKit-.patch
@@ -1,0 +1,81 @@
+From 77f7c62d6818967e3b5f7048c593d629fb40d9c3 Mon Sep 17 00:00:00 2001
+From: Adrian Perez de Castro <aperez@igalia.com>
+Date: Mon, 30 Sep 2024 16:36:52 +0300
+Subject: [PATCH] sysprofd: Check that remote user is root when PolKit is
+ disabled
+
+When PolKit support is enabled at build time, check that the remote user
+is "root" (and thus privileged) instead of always allowing access to
+methods of the sysprofd D-Bus interface.
+
+Upstream-Status: Submitted [https://gitlab.gnome.org/GNOME/sysprof/-/merge_requests/103]
+---
+ src/sysprofd/ipc-service-impl.c | 45 +++++++++++++++++++++++++++++++--
+ 1 file changed, 43 insertions(+), 2 deletions(-)
+
+diff --git a/src/sysprofd/ipc-service-impl.c b/src/sysprofd/ipc-service-impl.c
+index f1c1205..182159a 100644
+--- a/src/sysprofd/ipc-service-impl.c
++++ b/src/sysprofd/ipc-service-impl.c
+@@ -299,6 +299,49 @@ ipc_service_impl_g_authorize_method (GDBusInterfaceSkeleton *skeleton,
+ 
+   return ret;
+ }
++#else
++static gboolean
++ipc_service_impl_g_authorize_method (GDBusInterfaceSkeleton *skeleton,
++                                     GDBusMethodInvocation  *invocation)
++{
++  GDBusConnection *connection;
++  GCredentials *credentials;
++
++  g_assert (IPC_IS_SERVICE_IMPL (skeleton));
++  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
++
++  connection = g_dbus_method_invocation_get_connection (invocation);
++  credentials = g_dbus_connection_get_peer_credentials (connection);
++
++  if (credentials)
++    {
++      g_autoptr(GError) error = NULL;
++      uid_t peer_uid = g_credentials_get_unix_user (credentials, &error);
++      if (error)
++        {
++          g_assert(peer_uid == -1);
++          g_dbus_method_invocation_return_error (g_steal_pointer (&invocation),
++                                                 G_DBUS_ERROR,
++                                                 G_DBUS_ERROR_ACCESS_DENIED,
++                                                 "Could not obtain remote user credentials: %s",
++                                                 error->message);
++        }
++      else if (peer_uid == 0)
++        return TRUE;
++      else
++        g_dbus_method_invocation_return_error_literal (g_steal_pointer (&invocation),
++                                                       G_DBUS_ERROR,
++                                                       G_DBUS_ERROR_ACCESS_DENIED,
++                                                       "Not authorized to make request");
++    }
++  else
++    g_dbus_method_invocation_return_error_literal (g_steal_pointer (&invocation),
++                                                   G_DBUS_ERROR,
++                                                   G_DBUS_ERROR_ACCESS_DENIED,
++                                                   "Could not obtain connection peer credentials");
++
++  return FALSE;
++}
+ #endif
+ 
+ static gboolean
+@@ -444,11 +487,9 @@ G_DEFINE_TYPE_WITH_CODE (IpcServiceImpl, ipc_service_impl, IPC_TYPE_SERVICE_SKEL
+ static void
+ ipc_service_impl_class_init (IpcServiceImplClass *klass)
+ {
+-#if HAVE_POLKIT
+   GDBusInterfaceSkeletonClass *skeleton_class = G_DBUS_INTERFACE_SKELETON_CLASS (klass);
+ 
+   skeleton_class->g_authorize_method = ipc_service_impl_g_authorize_method;
+-#endif
+ 
+   signals [ACTIVITY] =
+     g_signal_new ("activity",

--- a/recipes-gnome/sysprof/sysprof_46.0.bb
+++ b/recipes-gnome/sysprof/sysprof_46.0.bb
@@ -1,0 +1,50 @@
+SUMMARY = "System-wide Performance Profiler for Linux"
+HOMEPAGE = "http://www.sysprof.com"
+LICENSE = "GPL-3.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504 \
+                    file://src/sysprof/sysprof-application.c;endline=17;md5=a3de8df3b0f8876dd01e1388d2d4b607"
+
+inherit gnomebase gnome-help gettext systemd gsettings gtk-icon-cache mime mime-xdg
+
+DEPENDS += " \
+    desktop-file-utils-native \
+    glib-2.0 \
+    glib-2.0-native \
+    json-glib \
+    libdex \
+    libunwind \
+    libxml2-native \
+    yelp-tools-native \
+"
+
+SRC_URI += "file://0001-meson-Check-for-libunwind-instead-of-libunwind-gener.patch \
+            file://0002-meson-Do-not-invoke-the-commands-to-update-the-icon-.patch \
+            file://0003-libsysprof-Check-for-unw_set_caching_policy-before-u.patch \
+            file://0001-Turn-polkit-agent-support-into-an-optional-feature.patch \
+            file://0002-Make-PolKit-usage-a-build-time-option.patch \
+            file://0003-sysprofd-Check-that-remote-user-is-root-when-PolKit-.patch \
+           "
+SRC_URI[archive.sha256sum] = "73aa7e75ebab3e4e0946a05a723df7e6ee4249e3b9e884dba35500aba2a1d176"
+
+PACKAGECONFIG ?= "${@bb.utils.contains('DISTRO_FEATURES', 'polkit', 'sysprofd libsysprof', '', d)} \
+                  ${@bb.utils.contains_any('DISTRO_FEATURES', '${GTK3DISTROFEATURES}', 'gtk', '', d)} \
+                 "
+
+PACKAGECONFIG[gtk] = "-Dgtk=true,-Dgtk=false,gtk4 libpanel"
+PACKAGECONFIG[sysprofd] = "-Dsysprofd=bundled,-Dsysprofd=none,polkit"
+PACKAGECONFIG[libsysprof] = "-Dlibsysprof=true,-Dlibsysprof=false,polkit"
+
+EXTRA_OEMESON += "-Dsystemdunitdir=${systemd_unitdir}/system"
+
+SOLIBS = ".so"
+FILES_SOLIBSDEV = "${libdir}/libsysprof-6.so"
+
+SYSTEMD_SERVICE:${PN} = "${@bb.utils.contains('PACKAGECONFIG', 'sysprofd', 'sysprof3.service', '', d)}"
+
+FILES:${PN} += " \
+    ${datadir}/dbus-1/system-services \
+    ${datadir}/dbus-1/system.d \
+    ${datadir}/dbus-1/interfaces \
+    ${datadir}/metainfo \
+    ${libdir}/libsysprof-6*.so.* \
+"


### PR DESCRIPTION
**Description:**  

This update introduces improvements to Poky-Wayland and WPEWebKit by enabling `polkit` and `sysprof` support. Additionally, the `sysprof` package has been upgraded to version 47.2.  

### Changes:  
- **Poky-Wayland**: Added `polkit` to `DISTRO_FEATURES` to support PolicyKit functionality.  
- **WPEWebKit**: Enabled `sysprof` profiling support by appending it to `PACKAGECONFIG`.  
- **Sysprof Upgrade**: Updated to version **47.2**, requiring `libdex` and `libpanel` dependencies.  
- **New Packages**: Added `libdex` (0.8.1) and `libpanel` (1.8.1) as dependencies for Sysprof UI.  
- **Upstream Submissions**: Related patches submitted to OpenEmbedded upstream ([[PR #896](https://github.com/openembedded/meta-openembedded/pull/896)](https://github.com/openembedded/meta-openembedded/pull/896)).  

### Impact:
  
- Enables profiling capabilities for WPEWebKit.  
- Improves policy management in Poky-Wayland via Polkit.  
