### PR TITLE
Add wpe-testbed and stress-ng to Image Install for Testing and Benchmarking  

### DIFF
--- a/.github/scripts/sanatizer-git-commit-messages
+++ b/.github/scripts/sanatizer-git-commit-messages
@@ -22,7 +22,7 @@ echo "$commits" > commit_messages.txt
 
 # Check commit messages format
 while IFS= read -r line; do
-  if ! [[ $line =~ ^[a-zA-Z0-9-]+:\ .+$ ]]; then
+  if ! [[ $line =~ ^[a-zA-Z0-9\_\-]+:\ .+$ ]]; then
     echo "Invalid commit message: $line"
     error_found=1
   fi

--- a/.github/workflows/test-build-wandboard-mesa-nightly-manually.yml
+++ b/.github/workflows/test-build-wandboard-mesa-nightly-manually.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
           bitbake_machine: ${{ matrix.machine }}
-          bitbake_source: 'poky-wayland layers.raspberrypi conf.wpe-${{ matrix.wpe_vers }} --update-config'
+          bitbake_source: 'poky-wayland layers.freescale conf.wpe-${{ matrix.wpe_vers }} --update-config'
           repo_release: ${{ matrix.yocto_rel }}
 
   test-wandboard-mesa-nightly:

--- a/.github/workflows/test-build-wandboard-mesa-stable-manually.yml
+++ b/.github/workflows/test-build-wandboard-mesa-stable-manually.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           bitbake_buildname: wpe-${{ matrix.wpe_vers }}-${{ matrix.machine }}
           bitbake_machine: ${{ matrix.machine }}
-          bitbake_source: 'poky-wayland layers.raspberrypi conf.wpe-${{ matrix.wpe_vers }} --update-config'
+          bitbake_source: 'poky-wayland layers.freescale conf.wpe-${{ matrix.wpe_vers }} --update-config'
           repo_release: ${{ matrix.yocto_rel }}
 
   test-wandboard-mesa-stable:

--- a/classes/image_browsers.bbclass
+++ b/classes/image_browsers.bbclass
@@ -44,6 +44,7 @@ IMAGE_INSTALL:append = " \
     e2fsprogs-e2fsck e2fsprogs-mke2fs e2fsprogs-tune2fs e2fsprogs-badblocks e2fsprogs-resize2fs \
     gdb \
     gdbserver \
+    glmark2 \
     gstreamer1.0-libav \
     mesa-demos \
     packagegroup-core-full-cmdline \

--- a/classes/image_browsers.bbclass
+++ b/classes/image_browsers.bbclass
@@ -45,6 +45,7 @@ IMAGE_INSTALL:append = " \
     gdb \
     gdbserver \
     gstreamer1.0-libav \
+    mesa-demos \
     packagegroup-core-full-cmdline \
     parted pv \
     perf \

--- a/classes/image_browsers.bbclass
+++ b/classes/image_browsers.bbclass
@@ -56,6 +56,7 @@ IMAGE_INSTALL:append = " \
     systemd-analyze \
     valgrind \
     weston-xwayland \
+    wpe-testbed \
     "
 
 # Dependencies for graphic demos based on Vulkan

--- a/classes/image_browsers.bbclass
+++ b/classes/image_browsers.bbclass
@@ -52,6 +52,7 @@ IMAGE_INSTALL:append = " \
     openssh-sftp \
     openssh-sftp-server \
     smem \
+    stress-ng \
     systemd-analyze \
     valgrind \
     weston-xwayland \

--- a/classes/image_browsers.bbclass
+++ b/classes/image_browsers.bbclass
@@ -48,6 +48,7 @@ IMAGE_INSTALL:append = " \
     packagegroup-core-full-cmdline \
     parted pv \
     perf \
+    python3-uinput \
     openssh-sftp \
     openssh-sftp-server \
     smem \

--- a/recipes-core/images/core-image-weston-wpe.bb
+++ b/recipes-core/images/core-image-weston-wpe.bb
@@ -5,7 +5,6 @@ inherit image_browsers image_weston
 IMAGE_INSTALL:append = " \
     wpewebkit \
     wpe-simple-launcher \
-    python3-uinput \
     sysprof \
 "
 


### PR DESCRIPTION
This PR adds the following packages to the `IMAGE_INSTALL` list to enhance testing and benchmarking capabilities:  

1. **wpe-testbed** – Enables testing for the WPEWebKit platform.  
2. **stress-ng** – Supports system stress testing for performance evaluation.  

- **Change-Type:** Minor  
- **Issue:** https://github.com/Igalia/meta-wpe-image/issues/38 
