### PR TITLE
image_browsers: Add igt-gpu-tools to image install

### DIFF
--- a/classes/image_browsers.bbclass
+++ b/classes/image_browsers.bbclass
@@ -46,6 +46,7 @@ IMAGE_INSTALL:append = " \
     gdbserver \
     glmark2 \
     gstreamer1.0-libav \
+    igt-gpu-tools \
     mesa-demos \
     packagegroup-core-full-cmdline \
     parted pv \


### PR DESCRIPTION
Included the igt-gpu-tools package in the IMAGE_INSTALL list to support development and testing of DRM drivers. This addition enhances the toolkit available for GPU-related tasks.

Change-Type: minor
Maintenance-Type: unreviewed-change