### PR TITLE
ci: Allow running single test or group of tests

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -31,6 +31,21 @@ Once the environment is running, you can trigger the tests with the
 ```sh
 ./run-tests.sh
 ```
+
+By default, the `run-tests.sh` script runs all the Robot Framework tests inside
+`.ci/robot_framework/tests`. To filter which tests to run, pass the path to the
+test as argument. For example:
+
+```sh
+./run-tests.sh robot_framework/tests/tests_005_basics.robot
+```
+
+It's possible to pass more than one test:
+
+```sh
+./run-tests.sh robot_framework/tests/tests_005_basics.robot robot_framework/tests/tests_010_input_events.robot
+```
+
 ### Services Setup
 
 The `./podman-compose.sh up` command initializes the following services:

--- a/.ci/robot_framework/run-robot.sh
+++ b/.ci/robot_framework/run-robot.sh
@@ -30,10 +30,25 @@ then
     ../../prepare-board.sh
 fi
 
+# Set tests to run.
+TESTS_DIR="../../robot_framework/tests"
+TESTS=()
+
+ARGS=($@)
+for each in ${ARGS[@]}; do
+    testname="$TESTS_DIR/$(basename "$each")"
+    TESTS+=($testname)
+done
+
+# In case no test set, run all tests.
+if [[ ${#TESTS[@]} -eq 0 ]]; then
+    TESTS+=("$TESTS_DIR/tests_*.robot")
+fi
+
+# Run tests.
 exec robot --name "WPE image tests" \
            --consolewidth 158 \
            --exclude skip \
            --skiponfailure ignoreonfail \
            --listener RetryFailed:2 \
-           ../../robot_framework/tests/tests_*.robot
-
+           "${TESTS[@]}"

--- a/.ci/run-tests.sh
+++ b/.ci/run-tests.sh
@@ -12,6 +12,7 @@ EOF
 # Check arguments
 force_recreate=false
 
+ARGS=""
 for arg in "$@"; do
     case $arg in
         --force-recreate)
@@ -21,10 +22,13 @@ for arg in "$@"; do
             show_help
             exit 0
             ;;
-        *)
+        --*)
             echo "Unknown option: $arg"
             show_help
             exit 1
+            ;;
+        *)
+            ARGS="$ARGS $arg"
             ;;
     esac
 done
@@ -35,6 +39,4 @@ if [ "$force_recreate" = true ]; then
 fi
 
 # Run the test script
-podman exec -ti ci_robot_1 ./robot_framework/run-robot.sh
-
-
+podman exec -ti ci_robot_1 ./robot_framework/run-robot.sh "$ARGS"


### PR DESCRIPTION
When launching 'run-tests.sh' allow passing list of tests to run. Otherwise, run all Robot tests.