### PR TITLE
weston: Add patches Fix dma-buf feedback issue

### DIFF
--- a/recipes-graphics/wayland/weston/0001-drm-try-other-planes-that-may-support-fences.patch
+++ b/recipes-graphics/wayland/weston/0001-drm-try-other-planes-that-may-support-fences.patch
@@ -1,0 +1,28 @@
+From f51d4f1f335e6cfa06549142d15e02bece9e6a90 Mon Sep 17 00:00:00 2001
+From: Leandro Ribeiro <leandro.ribeiro@collabora.com>
+Date: Mon, 23 Sep 2024 17:06:31 -0300
+Subject: [PATCH] drm: try other planes that may support fences
+
+Do not skip all the planes if a single one of them do not support
+fences. The other may do.
+
+Signed-off-by: Leandro Ribeiro <leandro.ribeiro@collabora.com>
+---
+ libweston/backend-drm/state-propose.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/1621]
+
+diff --git a/libweston/backend-drm/state-propose.c b/libweston/backend-drm/state-propose.c
+index 2b42e3d..74739ae 100644
+--- a/libweston/backend-drm/state-propose.c
++++ b/libweston/backend-drm/state-propose.c
+@@ -549,7 +549,7 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 		    plane->props[WDRM_PLANE_IN_FENCE_FD].prop_id == 0) {
+ 			drm_debug(b, "\t\t\t\t[%s] not placing view %p on %s: "
+ 			          "no in-fence support\n", p_name, ev, p_name);
+-			return NULL;
++			continue;
+ 		}
+ 
+ 		if (mode == DRM_OUTPUT_PROPOSE_STATE_MIXED) {

--- a/recipes-graphics/wayland/weston/0002-drm-fix-a-few-dma-buf-feedback-failure-reasons.patch
+++ b/recipes-graphics/wayland/weston/0002-drm-fix-a-few-dma-buf-feedback-failure-reasons.patch
@@ -1,0 +1,76 @@
+From 707a38a8c2b29555f5a97891d0f10ac5868fbf18 Mon Sep 17 00:00:00 2001
+From: Leandro Ribeiro <leandro.ribeiro@collabora.com>
+Date: Tue, 24 Sep 2024 10:08:05 -0300
+Subject: [PATCH] drm: fix a few dma-buf feedback failure reasons
+
+There are a few points in the code where we are wrongly using
+FAILURE_REASONS_ADD_FB_FAILED, probably because we didn't have so many
+"failure reasons" previously. This update such cases to use enum's that
+make sense.
+
+Signed-off-by: Leandro Ribeiro <leandro.ribeiro@collabora.com>
+---
+ libweston/backend-drm/drm-internal.h  | 11 ++++++-----
+ libweston/backend-drm/state-propose.c |  8 ++++----
+ 2 files changed, 10 insertions(+), 9 deletions(-)
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/1621]
+
+diff --git a/libweston/backend-drm/drm-internal.h b/libweston/backend-drm/drm-internal.h
+index 48bc243..8405e8a 100644
+--- a/libweston/backend-drm/drm-internal.h
++++ b/libweston/backend-drm/drm-internal.h
+@@ -282,11 +282,12 @@ enum try_view_on_plane_failure_reasons {
+ 	FAILURE_REASONS_INADEQUATE_CONTENT_PROTECTION = 1 << 6,
+ 	FAILURE_REASONS_INCOMPATIBLE_TRANSFORM = 1 << 7,
+ 	FAILURE_REASONS_NO_BUFFER = 1 << 8,
+-	FAILURE_REASONS_BUFFER_TYPE = 1 << 9,
+-	FAILURE_REASONS_GLOBAL_ALPHA = 1 << 10,
+-	FAILURE_REASONS_NO_GBM = 1 << 11,
+-	FAILURE_REASONS_GBM_BO_IMPORT_FAILED = 1 << 12,
+-	FAILURE_REASONS_GBM_BO_GET_HANDLE_FAILED = 1 << 13,
++	FAILURE_REASONS_BUFFER_TOO_BIG = 1 << 9,
++	FAILURE_REASONS_BUFFER_TYPE = 1 << 10,
++	FAILURE_REASONS_GLOBAL_ALPHA = 1 << 11,
++	FAILURE_REASONS_NO_GBM = 1 << 12,
++	FAILURE_REASONS_GBM_BO_IMPORT_FAILED = 1 << 13,
++	FAILURE_REASONS_GBM_BO_GET_HANDLE_FAILED = 1 << 14,
+ };
+ 
+ /**
+diff --git a/libweston/backend-drm/state-propose.c b/libweston/backend-drm/state-propose.c
+index 74739ae..30b287e 100644
+--- a/libweston/backend-drm/state-propose.c
++++ b/libweston/backend-drm/state-propose.c
+@@ -400,19 +400,19 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 	/* check view for valid buffer, doesn't make sense to even try */
+ 	if (!weston_view_has_valid_buffer(ev)) {
+ 		pnode->try_view_on_plane_failure_reasons |=
+-			FAILURE_REASONS_FB_FORMAT_INCOMPATIBLE;
++			FAILURE_REASONS_NO_BUFFER;
+ 		return NULL;
+ 	}
+ 
+ 	buffer = ev->surface->buffer_ref.buffer;
+ 	if (buffer->type == WESTON_BUFFER_SOLID) {
+ 		pnode->try_view_on_plane_failure_reasons |=
+-			FAILURE_REASONS_FB_FORMAT_INCOMPATIBLE;
++			FAILURE_REASONS_BUFFER_TYPE;
+ 		return NULL;
+ 	} else if (buffer->type == WESTON_BUFFER_SHM) {
+ 		if (!output->cursor_plane || device->cursors_are_broken) {
+ 			pnode->try_view_on_plane_failure_reasons |=
+-				FAILURE_REASONS_FB_FORMAT_INCOMPATIBLE;
++				FAILURE_REASONS_BUFFER_TYPE;
+ 			return NULL;
+ 		}
+ 
+@@ -433,7 +433,7 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 				     "(buffer (%dx%d) too large for cursor plane)\n",
+ 				     ev, buffer->width, buffer->height);
+ 			pnode->try_view_on_plane_failure_reasons |=
+-				FAILURE_REASONS_FB_FORMAT_INCOMPATIBLE;
++				FAILURE_REASONS_BUFFER_TOO_BIG;
+ 			return NULL;
+ 		}
+ 

--- a/recipes-graphics/wayland/weston/0003-drm-fix-issue-with-enum-being-wrongly-used.patch
+++ b/recipes-graphics/wayland/weston/0003-drm-fix-issue-with-enum-being-wrongly-used.patch
@@ -1,0 +1,32 @@
+From 2ece717ab5dfc20413d9332c4b917a18bc495c6f Mon Sep 17 00:00:00 2001
+From: Leandro Ribeiro <leandro.ribeiro@collabora.com>
+Date: Tue, 24 Sep 2024 10:08:51 -0300
+Subject: [PATCH] drm: fix issue with enum being wrongly used
+
+FAILURE_REASONS_ADD_FB_FAILED is defined as (1 << 3), so when we are
+accumulating "failure reasons" in a variable we don't need to do the bit
+shift again.
+
+This results in an issue, because (1 << FAILURE_REASONS_ADD_FB_FAILED)
+results in (1 << (1 << 3)) == (1 << 8).
+
+Signed-off-by: Leandro Ribeiro <leandro.ribeiro@collabora.com>
+---
+ libweston/backend-drm/fb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/1621]
+
+diff --git a/libweston/backend-drm/fb.c b/libweston/backend-drm/fb.c
+index 8c200b8..09436e6 100644
+--- a/libweston/backend-drm/fb.c
++++ b/libweston/backend-drm/fb.c
+@@ -743,7 +743,7 @@ drm_fb_get_from_paint_node(struct drm_output_state *state,
+ 		fb = drm_fb_get_from_bo(bo, device, is_opaque, BUFFER_CLIENT);
+ 		if (!fb) {
+ 			pnode->try_view_on_plane_failure_reasons |=
+-				(1 << FAILURE_REASONS_ADD_FB_FAILED);
++				FAILURE_REASONS_ADD_FB_FAILED;
+ 			gbm_bo_destroy(bo);
+ 			goto unsuitable;
+ 		}

--- a/recipes-graphics/wayland/weston/0004-drm-avoid-dma-buf-feedback-endless-loop.patch
+++ b/recipes-graphics/wayland/weston/0004-drm-avoid-dma-buf-feedback-endless-loop.patch
@@ -1,0 +1,158 @@
+From 602ff2de75ee0c82dc721f9092d0c804d74c00e8 Mon Sep 17 00:00:00 2001
+From: Leandro Ribeiro <leandro.ribeiro@collabora.com>
+Date: Tue, 24 Sep 2024 11:23:50 -0300
+Subject: [PATCH] drm: avoid dma-buf feedback endless loop
+
+Currently we have the following situation: we add a scanout tranche
+because if the client re-allocates with another format/modifier, the
+chances of being placed in a DRM/KMS plane is higher.
+
+But then we run out of overlay planes. So we remove the scanout tranche,
+because the format/modifier available in the renderer tranche are
+optimal for rendering.
+
+Now Weston detects again that the format/modifier is what may be
+avoiding the view being place in a plane, re-adding the scanout tranche.
+And we have an endless loop.
+
+To avoid this, let's accumulate the reasons why placing the view in a
+place failed. So if we detect that we don't have planes available, no
+matter the format/modifier, we won't add the scanout tranche.
+
+Signed-off-by: Leandro Ribeiro <leandro.ribeiro@collabora.com>
+---
+ libweston/backend-drm/state-propose.c | 45 +++++++++++----------------
+ 1 file changed, 18 insertions(+), 27 deletions(-)
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/1621]
+
+diff --git a/libweston/backend-drm/state-propose.c b/libweston/backend-drm/state-propose.c
+index 30b287e..f4008dc 100644
+--- a/libweston/backend-drm/state-propose.c
++++ b/libweston/backend-drm/state-propose.c
+@@ -394,6 +394,7 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 
+ 	bool view_matches_entire_output, scanout_has_view_assigned;
+ 	uint32_t possible_plane_mask = 0;
++	bool any_candidate_picked = false;
+ 
+ 	pnode->try_view_on_plane_failure_reasons = FAILURE_REASONS_NONE;
+ 
+@@ -408,23 +409,19 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 	if (buffer->type == WESTON_BUFFER_SOLID) {
+ 		pnode->try_view_on_plane_failure_reasons |=
+ 			FAILURE_REASONS_BUFFER_TYPE;
+-		return NULL;
+ 	} else if (buffer->type == WESTON_BUFFER_SHM) {
+-		if (!output->cursor_plane || device->cursors_are_broken) {
++		if (!output->cursor_plane || device->cursors_are_broken)
+ 			pnode->try_view_on_plane_failure_reasons |=
+ 				FAILURE_REASONS_BUFFER_TYPE;
+-			return NULL;
+-		}
+ 
+-		/* Even though this is a SHM buffer, pixel_format stores the
+-		 * format code as DRM FourCC */
++		/* Even though this is a SHM buffer, pixel_format stores
++		 * the format code as DRM FourCC */
+ 		if (buffer->pixel_format->format != DRM_FORMAT_ARGB8888) {
+ 			drm_debug(b, "\t\t\t\t[view] not placing view %p on "
+-			             "plane; SHM buffers must be ARGB8888 for "
++				     "plane; SHM buffers must be ARGB8888 for "
+ 				     "cursor view\n", ev);
+ 			pnode->try_view_on_plane_failure_reasons |=
+ 				FAILURE_REASONS_FB_FORMAT_INCOMPATIBLE;
+-			return NULL;
+ 		}
+ 
+ 		if (buffer->width > device->cursor_width ||
+@@ -434,10 +431,10 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 				     ev, buffer->width, buffer->height);
+ 			pnode->try_view_on_plane_failure_reasons |=
+ 				FAILURE_REASONS_BUFFER_TOO_BIG;
+-			return NULL;
+ 		}
+ 
+-		possible_plane_mask = (1 << output->cursor_plane->plane_idx);
++		if (pnode->try_view_on_plane_failure_reasons == FAILURE_REASONS_NONE)
++			possible_plane_mask = (1 << output->cursor_plane->plane_idx);
+ 	} else {
+ 		if (mode == DRM_OUTPUT_PROPOSE_STATE_RENDERER_ONLY) {
+ 			drm_debug(b, "\t\t\t\t[view] not assigning view %p "
+@@ -453,20 +450,16 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 				possible_plane_mask |= 1 << plane->plane_idx;
+ 		}
+ 
+-		if (!possible_plane_mask) {
++		if (!possible_plane_mask)
+ 			pnode->try_view_on_plane_failure_reasons |=
+ 				FAILURE_REASONS_INCOMPATIBLE_TRANSFORM;
+-			return NULL;
+-		}
+ 
+ 		fb = drm_fb_get_from_paint_node(state, pnode);
+-		if (!fb) {
++		if (fb)
++			possible_plane_mask &= fb->plane_mask;
++		else
+ 			drm_debug(b, "\t\t\t[view] couldn't get FB for view: 0x%lx\n",
+-				  (unsigned long) pnode->try_view_on_plane_failure_reasons);
+-			return NULL;
+-		}
+-
+-		possible_plane_mask &= fb->plane_mask;
++				     (unsigned long) pnode->try_view_on_plane_failure_reasons);
+ 	}
+ 
+ 	view_matches_entire_output =
+@@ -494,7 +487,6 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 			assert(plane == output->cursor_plane);
+ 			break;
+ 		case WDRM_PLANE_TYPE_PRIMARY:
+-			assert(fb);
+ 			if (plane != output->scanout_plane)
+ 				continue;
+ 			if (mode != DRM_OUTPUT_PROPOSE_STATE_PLANES_ONLY)
+@@ -503,7 +495,6 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 				continue;
+ 			break;
+ 		case WDRM_PLANE_TYPE_OVERLAY:
+-			assert(fb);
+ 			assert(mode != DRM_OUTPUT_PROPOSE_STATE_RENDERER_ONLY);
+ 			/* if the view covers the whole output, put it in the
+ 			 * scanout plane, not overlay */
+@@ -570,6 +561,7 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 		else
+ 			zpos = MIN(current_lowest_zpos - 1, plane->zpos_max);
+ 
++		any_candidate_picked = true;
+ 		drm_debug(b, "\t\t\t\t[plane] plane %d picked "
+ 			     "from candidate list, type: %s\n",
+ 			     plane->plane_id, p_name);
+@@ -577,9 +569,10 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 		if (plane->type == WDRM_PLANE_TYPE_CURSOR) {
+ 			ps = drm_output_prepare_cursor_paint_node(state, pnode, zpos);
+ 		} else {
+-			ps = drm_output_try_paint_node_on_plane(plane, state,
+-								pnode, mode,
+-								fb, zpos);
++			if (fb)
++				ps = drm_output_try_paint_node_on_plane(plane, state,
++									pnode, mode,
++									fb, zpos);
+ 		}
+ 
+ 		if (ps) {
+@@ -593,11 +586,9 @@ drm_output_find_plane_for_view(struct drm_output_state *state,
+ 			FAILURE_REASONS_PLANES_REJECTED;
+ 	}
+ 
+-	if (!ps &&
+-	    pnode->try_view_on_plane_failure_reasons == FAILURE_REASONS_NONE) {
++	if (!any_candidate_picked)
+ 		pnode->try_view_on_plane_failure_reasons |=
+ 			FAILURE_REASONS_NO_PLANES_AVAILABLE;
+-	}
+ 
+ 	/* if we have a plane state, it has its own ref to the fb; if not then
+ 	 * we drop ours here */

--- a/recipes-graphics/wayland/weston_13.0.1.bbappend
+++ b/recipes-graphics/wayland/weston_13.0.1.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-drm-try-other-planes-that-may-support-fences.patch \
+            file://0002-drm-fix-a-few-dma-buf-feedback-failure-reasons.patch \
+            file://0003-drm-fix-issue-with-enum-being-wrongly-used.patch \
+            file://0004-drm-avoid-dma-buf-feedback-endless-loop.patch \
+"


### PR DESCRIPTION
Added several patches to the `weston` recipe to enhance DRM functionality:

- **0001**: Allows trying other planes that may support fences.
- **0002**: Corrects dma-buf feedback failure reasons.
- **0003**: Fixes an issue with enum usage in failure reasons.
- **0004**: Prevents dma-buf feedback endless loop by accumulating failure reasons.

Fix endless loop negotiation with dma-buf feedback. Also adds a few general improvements to dma-buf feedback.

Upstream-Status: Backport [https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/1621]
Change-Type: patch