### PR TITLE
ci,tests: Improve webdriver reliability in video and canvas tests

### DIFF
--- a/.ci/robot_framework/tests/tests_005_basics.robot
+++ b/.ci/robot_framework/tests/tests_005_basics.robot
@@ -17,3 +17,14 @@ Check L2 Cache is enabled
     ${TEST_BOARD_IP}    Get Environment Variable    TEST_BOARD_IP
     ${stdout}=    SSH Command    ${TEST_BOARD_IP}   /root/scripts/check-l2-cache-is-enabled.sh
     Should Be Equal As Strings  ${stdout}[0]  L2 cache enabled
+
+Check Weston Service
+    Wait Until Keyword Succeeds    3x    1000ms    Start And Status Weston Service
+
+*** Keywords ***
+Start And Status Weston Service
+    ${TEST_BOARD_IP}=    Get Environment Variable    TEST_BOARD_IP
+    SSH Command    ${TEST_BOARD_IP}    systemctl start weston
+    ${stdout}=    SSH Command    ${TEST_BOARD_IP}    systemctl status weston
+    Should Contain    ${stdout}[0]    Active: active (running)
+

--- a/.ci/robot_framework/tests/tests_015_video.robot
+++ b/.ci/robot_framework/tests/tests_015_video.robot
@@ -2,7 +2,7 @@
 
 Test Timeout    300 seconds
 
-Suite Setup       Webdriver Remote Start    --maximized
+Suite Setup       Wait Until Keyword Succeeds    20x   1000ms    Webdriver Remote Start Maximized
 Suite Teardown    Webdriver Remote Stop
 
 Library    SeleniumLibrary

--- a/.ci/robot_framework/tests/tests_017_canvas.robot
+++ b/.ci/robot_framework/tests/tests_017_canvas.robot
@@ -2,7 +2,7 @@
 
 Test Timeout    300 seconds
 
-Suite Setup       Webdriver Remote Start    --maximized
+Suite Setup       Wait Until Keyword Succeeds    20x   1000ms    Webdriver Remote Start Maximized
 Suite Teardown    Webdriver Remote Stop
 
 Library    SeleniumLibrary


### PR DESCRIPTION
Updated `tests_015_video.robot` and `tests_017_canvas.robot` to use the `Wait Until Keyword Succeeds` mechanism for the `Webdriver Remote Start Maximized` setup. This change enhances the reliability of the test suite by ensuring the browser is maximized and ready before tests proceed, reducing the likelihood of failures due to browser state issues.

Maintenance-Type: unreviewed-change