### PR TITLE
ci,tests: Add test '2D Rendering Stress Test'

### DIFF
--- a/.ci/robot_framework/tests/tests_006_stress_ng.robot
+++ b/.ci/robot_framework/tests/tests_006_stress_ng.robot
@@ -24,3 +24,9 @@ Memory Stress Test
     ${stdout}=        SSH Command                               ${TEST_BOARD_IP}             /root/scripts/stress-test.py --report --filter memory
     ${data}=          Evaluate                                  json.loads('''${stdout}[0]''')  json
     Should Be True    ${data['actual']} >= ${data['expected']}
+
+2D Rendering Stress Test
+    ${TEST_BOARD_IP}  Get Environment Variable                  TEST_BOARD_IP
+    ${stdout}=        SSH Command                               ${TEST_BOARD_IP}                /root/scripts/stress-test.py --report --filter rendering
+    ${data}=          Evaluate                                  json.loads('''${stdout}[0]''')  json
+    Should Be True    ${data['actual']} >= ${data['expected']}

--- a/.ci/scripts/stress-test.py
+++ b/.ci/scripts/stress-test.py
@@ -25,7 +25,7 @@ def run_stress_test(cmd):
     cmd = "%s --metrics-brief --yaml %s &>/dev/null" % (cmd, output)
     subprocess.run(cmd, shell=True, stdout=subprocess.PIPE)
 
-    if not os.path.exists(output):
+    if not os.path.exists(output) or os.stat(output).st_size == 0:
         return
 
     metrics = parse_yaml(output)
@@ -53,11 +53,13 @@ def parse_yaml(filename):
     return results
 
 def run_glmark2_es2_wayland():
+    WAYLAND_DISPLAY="/run/wayland-0"
     output = "/tmp/results.xml"
-    cmd = "glmark2-es2-wayland -b effect2d:duration=5.0 --results-file %s &>/dev/null" % output
+
+    cmd = f"WAYLAND_DISPLAY={WAYLAND_DISPLAY} glmark2-es2-wayland -b effect2d:duration=5.0 --results-file {output} &>/dev/null"
     subprocess.run(cmd, shell=True, stdout=subprocess.PIPE)
 
-    if not os.path.exists(output):
+    if not os.path.exists(output) or os.stat(output).st_size == 0:
         return
 
     with open(output, "r") as fd:
@@ -133,7 +135,7 @@ def get_platform():
         return "other"
 
 def dump(results):
-	print(json.dumps(results))
+    print(json.dumps(results))
 
 def main(argument_list):
     args = parse_args(argument_list)

--- a/.ci/tests-baselines/stress-tests/rpi3-expected.json
+++ b/.ci/tests-baselines/stress-tests/rpi3-expected.json
@@ -1,1 +1,1 @@
-{"cpu_1_core": 2200, "cpu_4_core": 8600, "memory": 15800, "rendering": 450}
+{"cpu_1_core": 2200, "cpu_4_core": 8600, "memory": 15800, "rendering": 360}


### PR DESCRIPTION
Partially fixes: https://github.com/Igalia/meta-wpe-image/issues/38

Executes command:

```bash
glmark2-es2-wayland -b effect2d:duration=5.0
```

and obtains results.

There was a tricky part when running this command over SSH. It was necessary to define `WAYLAND_DISPLAY` when running `glmark2-es2-wayland`.