### PR TITLE
ci: Add test for CONFIG_HID_MULTITOUCH kernel configuration

### DIFF
--- a/.ci/robot_framework/tests/tests_005_basics.robot
+++ b/.ci/robot_framework/tests/tests_005_basics.robot
@@ -18,6 +18,17 @@ Check L2 Cache is enabled
     ${stdout}=    SSH Command    ${TEST_BOARD_IP}   /root/scripts/check-l2-cache-is-enabled.sh
     Should Be Equal As Strings  ${stdout}[0]  L2 cache enabled
 
+Check Kernel Configuration CONFIG_HID_MULTITOUCH Is Enabled
+    [Documentation]    Verify that the kernel configuration contains
+    ...                CONFIG_HID_MULTITOUCH enabled. This ensures that
+    ...                multitouch input support is available in the kernel.
+    ...                The test fails if the configuration is missing or
+    ...                explicitly disabled.
+    ${TEST_BOARD_IP}    Get Environment Variable    TEST_BOARD_IP
+    ${stdout}=    SSH Command    ${TEST_BOARD_IP}    zcat /proc/config.gz | grep "CONFIG_HID_MULTITOUCH"
+    Log    ${stdout}
+    Should Not Contain    ${stdout}[0]    CONFIG_HID_MULTITOUCH is not set
+
 Check Weston Service
     Wait Until Keyword Succeeds    3x    1000ms    Start And Status Weston Service
 


### PR DESCRIPTION
Introduce a new test to verify CONFIG_HID_MULTITOUCH is enabled in the kernel

Maintenance-Type: ci