### PR TITLE
raspberrypi: Remove bcm2712d0 overlay from RPi3/4 configs

### DIFF
--- a/conf/machine/raspberrypi3-64-mesa.conf
+++ b/conf/machine/raspberrypi3-64-mesa.conf
@@ -6,6 +6,8 @@ PREFERRED_VERSION_linux-raspberrypi = "6.1.%"
 
 MACHINE_FEATURES += "vc4graphics"
 
+RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/bcm2712d0.dtbo"
+
 GPU_MEM_256 = "128"
 GPU_MEM_512 = "128"
 GPU_MEM_1024 = "128"

--- a/conf/machine/raspberrypi3-mesa.conf
+++ b/conf/machine/raspberrypi3-mesa.conf
@@ -18,6 +18,8 @@ MACHINEOVERRIDES =. "use-mainline-bsp:raspberrypi3:"
 
 MACHINE_FEATURES += "vc4graphics"
 
+RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/bcm2712d0.dtbo"
+
 GPU_MEM_256 = "128"
 GPU_MEM_512 = "128"
 GPU_MEM_1024 = "128"

--- a/conf/machine/raspberrypi3-userland.conf
+++ b/conf/machine/raspberrypi3-userland.conf
@@ -4,6 +4,8 @@ MACHINEOVERRIDES =. "raspberrypi3:"
 
 MACHINE_FEATURES:remove = "vc4graphics"
 
+RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/bcm2712d0.dtbo"
+
 GPU_MEM_256 = "128"
 GPU_MEM_512 = "196"
 GPU_MEM_1024 = "256"

--- a/conf/machine/raspberrypi4-64-mesa.conf
+++ b/conf/machine/raspberrypi4-64-mesa.conf
@@ -4,6 +4,8 @@ PREFERRED_VERSION_linux-raspberrypi = "6.1.%"
 
 MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberrypi4-64:${MACHINE}')}"
 
+RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/bcm2712d0.dtbo"
+
 GPU_MEM_256 = "128"
 GPU_MEM_512 = "196"
 GPU_MEM_1024 = "256"

--- a/conf/machine/raspberrypi4-mesa.conf
+++ b/conf/machine/raspberrypi4-mesa.conf
@@ -4,6 +4,8 @@ PREFERRED_VERSION_linux-raspberrypi = "6.1.%"
 
 MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberrypi4:${MACHINE}')}"
 
+RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/bcm2712d0.dtbo"
+
 GPU_MEM_256 = "128"
 GPU_MEM_512 = "196"
 GPU_MEM_1024 = "256"


### PR DESCRIPTION
Exclude bcm2712d0 overlay from device tree overlays for all raspberrypi3 and 4 variants.
    
This prevents applying an incompatible overlay on these models.
    
Related-To: https://github.com/agherzan/meta-raspberrypi/pull/1460
    
Change-Type: patch
