### PR TITLE
Add `synaptics-killswitch` to the list of accepted licenses

### DIFF
--- a/conf/templates/template/presets/conf.conf
+++ b/conf/templates/template/presets/conf.conf
@@ -25,7 +25,8 @@ CONF_VERSION = "2"
 DL_DIR ?= "${BSPDIR}/downloads/"
 ACCEPT_FSL_EULA = "1"
 
-LICENSE_FLAGS_ACCEPTED="commercial"
+LICENSE_FLAGS_ACCEPTED = "commercial"
+LICENSE_FLAGS_ACCEPTED:append:rpi = " synaptics-killswitch"
 
 # Clang based cross compiler is not included into the generated SDK using bitbake
 # meta-toolchain or bitbake -cpopulate_sdk <image> if clang is expected to be


### PR DESCRIPTION
It is required to build Raspberry Pi images.