### PR TITLE
ci: Enhance test coverage and add build information

### DIFF
--- a/.ci/robot_framework/tests/tests_005_basics.robot
+++ b/.ci/robot_framework/tests/tests_005_basics.robot
@@ -7,6 +7,18 @@ Library    ../libs/TestUtils.py
 Resource   variables.robot
 
 *** Test Cases ***
+List buildinfo
+    ${TEST_BOARD_IP}    Get Environment Variable    TEST_BOARD_IP
+    ${stdout}=    SSH Command    ${TEST_BOARD_IP}    cat /etc/buildinfo
+    ${formatted}=    Evaluate    """${stdout}[0]"""
+    Log    ${formatted}
+
+List installed packages
+    ${TEST_BOARD_IP}    Get Environment Variable    TEST_BOARD_IP
+    ${stdout}=    SSH Command    ${TEST_BOARD_IP}    rpm -qa
+    ${formatted}=    Evaluate    """${stdout}[0]"""
+    Log    ${formatted}
+
 Check Kernel Configuration available in /proc/config.gz
     ${TEST_BOARD_IP}    Get Environment Variable    TEST_BOARD_IP
     ${stdout}=    SSH Command    ${TEST_BOARD_IP}    zcat /proc/config.gz |grep "Kernel Configuration"

--- a/conf/distro/poky-wayland.conf
+++ b/conf/distro/poky-wayland.conf
@@ -19,6 +19,12 @@ DISTRO_FEATURES:append = " egl \
 
 DISTRO_FEATURES:remove = "ptest"
 
+# Add build information in the image (/etc/buildinfo)
+INHERIT += "image-buildinfo"
+IMAGE_BUILDINFO_VARS:append = " DATETIME DISTRO_NAME IMAGE_BASENAME MACHINE TUNE_PKGARCH"
+IMAGE_BUILDINFO_VARS:append = " MACHINE_FEATURES DISTRO_FEATURES COMMON_FEATURES IMAGE_FEATURES"
+IMAGE_BUILDINFO_VARS:append = " TUNE_FEATURES TARGET_FPU"
+
 # Set wpebackend-fdo as wpebackend provider
 PREFERRED_PROVIDER_virtual/wpebackend ?= "wpebackend-fdo"
 


### PR DESCRIPTION
Provide detailed build information for better traceability by updating `poky-wayland` distro to include build:

* `image-buildinfo` to `INHERIT`.
* Relevant variables to `IMAGE_BUILDINFO_VARS`.

Also add new test cases in `tests_005_basics.robot`:

* `List buildinfo`: Retrieve and log build information from `/etc/buildinfo`.
* `List installed packages`: Retrieve and log installed packages using `rpm -qa`.

Change-Type: minor
Maintenance-Type: ci