### PR TITLE
conf: Remove w1-gpio-pi5 devicetree overlay for rpi 3 and 4

### DIFF
--- a/conf/machine/raspberrypi3-64-mesa.conf
+++ b/conf/machine/raspberrypi3-64-mesa.conf
@@ -8,6 +8,7 @@ MACHINE_FEATURES += "vc4graphics"
 
 RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/bcm2712d0.dtbo"
 RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/vc4-kms-dsi-ili9881-7inch.dtbo"
+RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/w1-gpio-pi5.dtbo"
 
 GPU_MEM_256 = "128"
 GPU_MEM_512 = "128"

--- a/conf/machine/raspberrypi3-mesa.conf
+++ b/conf/machine/raspberrypi3-mesa.conf
@@ -20,6 +20,7 @@ MACHINE_FEATURES += "vc4graphics"
 
 RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/bcm2712d0.dtbo"
 RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/vc4-kms-dsi-ili9881-7inch.dtbo"
+RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/w1-gpio-pi5.dtbo"
 
 GPU_MEM_256 = "128"
 GPU_MEM_512 = "128"

--- a/conf/machine/raspberrypi3-userland.conf
+++ b/conf/machine/raspberrypi3-userland.conf
@@ -6,6 +6,7 @@ MACHINE_FEATURES:remove = "vc4graphics"
 
 RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/bcm2712d0.dtbo"
 RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/vc4-kms-dsi-ili9881-7inch.dtbo"
+RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/w1-gpio-pi5.dtbo"
 
 GPU_MEM_256 = "128"
 GPU_MEM_512 = "196"

--- a/conf/machine/raspberrypi4-64-mesa.conf
+++ b/conf/machine/raspberrypi4-64-mesa.conf
@@ -6,6 +6,7 @@ MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberryp
 
 RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/bcm2712d0.dtbo"
 RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/vc4-kms-dsi-ili9881-7inch.dtbo"
+RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/w1-gpio-pi5.dtbo"
 
 GPU_MEM_256 = "128"
 GPU_MEM_512 = "196"

--- a/conf/machine/raspberrypi4-mesa.conf
+++ b/conf/machine/raspberrypi4-mesa.conf
@@ -6,6 +6,7 @@ MACHINEOVERRIDES := "${@'${MACHINEOVERRIDES}'.replace(':${MACHINE}',':raspberryp
 
 RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/bcm2712d0.dtbo"
 RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/vc4-kms-dsi-ili9881-7inch.dtbo"
+RPI_KERNEL_DEVICETREE_OVERLAYS:remove = "overlays/w1-gpio-pi5.dtbo"
 
 GPU_MEM_256 = "128"
 GPU_MEM_512 = "196"


### PR DESCRIPTION
Remove `overlays/w1-gpio-pi5.dtbo` from `RPI_KERNEL_DEVICETREE_OVERLAYS` in the following configurations:

* `raspberrypi3-64-mesa.conf`
* `raspberrypi3-mesa.conf`
* `raspberrypi3-userland.conf`
* `raspberrypi4-64-mesa.conf`
* `raspberrypi4-mesa.conf`

These changes ensure that the `w1-gpio-pi5` overlay is not included in the device tree for the non rpi5 machine definitions.

Change-Type: patch
Related-To: https://github.com/agherzan/meta-raspberrypi/pull/1525