### PR TITLE
raspberrypi: Fix build for raspberrypi3

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit/0001-Add-LAYER_BASED_SVG_ENGINE-envvar_v2.50.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/0001-Add-LAYER_BASED_SVG_ENGINE-envvar_v2.50.patch
@@ -1,9 +1,8 @@
-From 5fb4b3703fc19683a3689d3df557560079a71df0 Mon Sep 17 00:00:00 2001
+From a25216c56a57e35496ca5f1e043c1685b8eb5298 Mon Sep 17 00:00:00 2001
 From: Pablo Saavedra <psaavedra@igalia.com>
 Date: Wed, 24 May 2023 13:50:19 +0000
-Subject: [PATCH] Add LAYER_BASED_SVG_ENGINE and
+Subject: Add LAYER_BASED_SVG_ENGINE and LAYER_BASED_SVG_ENGINE_TOGGLER envvars
 
- LAYER_BASED_SVG_ENGINE_TOGGLER envvars
 ---
  .../UIProcess/API/glib/WebKitWebView.cpp      |  3 +++
  Source/WebKit/UIProcess/WebPageProxy.cpp      |  2 ++
@@ -11,7 +10,7 @@ Subject: [PATCH] Add LAYER_BASED_SVG_ENGINE and
  3 files changed, 30 insertions(+)
 
 diff --git a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
-index 277b4cdf..4ae56c8e 100644
+index 277b4cdf400f..4ae56c8ef1d3 100644
 --- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 +++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
 @@ -3578,6 +3578,9 @@ void webkit_web_view_reload(WebKitWebView* webView)
@@ -25,7 +24,7 @@ index 277b4cdf..4ae56c8e 100644
  }
  
 diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
-index ffa22ccd..e8771a55 100644
+index d3967b989dfe..2795c3b135b5 100644
 --- a/Source/WebKit/UIProcess/WebPageProxy.cpp
 +++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
 @@ -1147,8 +1147,10 @@ void WebPageProxy::notifyProcessPoolToPrewarm()
@@ -40,10 +39,10 @@ index ffa22ccd..e8771a55 100644
      protectedPreferences()->removePage(*this);
      m_preferences = preferences;
 diff --git a/Source/WebKit/WebProcess/WebPage/WebPage.cpp b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-index bf2d3f7e..ea95b826 100644
+index 54ab23ec581c..2334446b86dc 100644
 --- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
 +++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
-@@ -497,6 +497,10 @@
+@@ -498,6 +498,10 @@
  #include <WebKitAdditions/WebPreferencesDefaultValuesAdditions.h>
  #endif
  
@@ -54,7 +53,7 @@ index bf2d3f7e..ea95b826 100644
  namespace WebKit {
  using namespace JSC;
  using namespace WebCore;
-@@ -4781,6 +4785,27 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
+@@ -4782,6 +4786,27 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
  
      updateSettingsGenerated(store, settings);
  
@@ -67,7 +66,7 @@ index bf2d3f7e..ea95b826 100644
 +        } else {
 +            fprintf(stderr, "LAYER_BASED_SVG_ENGINE: 0 ('%s' the toggler doesn't exist)\n", lbseEnabledToggler);
 +            settings.setLayerBasedSVGEngineEnabled(false);
-+	}
++       }
 +    } else {
 +        const char* lbseEnabled = getenv("LAYER_BASED_SVG_ENGINE");
 +        if (lbseEnabled != NULL && strcmp(lbseEnabled, "1") == 0) {
@@ -82,3 +81,4 @@ index bf2d3f7e..ea95b826 100644
  #if !PLATFORM(GTK) && !PLATFORM(WIN) && !PLATFORM(PLAYSTATION)
      if (!settings.acceleratedCompositingEnabled()) {
          WEBPAGE_RELEASE_LOG(Layers, "updatePreferences: acceleratedCompositingEnabled setting was false. WebKit cannot function in this mode; changing setting to true");
+

--- a/recipes-browser/wpewebkit/wpewebkit_2.50.%.bbappend
+++ b/recipes-browser/wpewebkit/wpewebkit_2.50.%.bbappend
@@ -17,5 +17,7 @@ PACKAGECONFIG:remove = "speech-synthesis"
 TOOLCHAIN:aarch64 = "clang"
 LIBCPLUSPLUS:aarch64 = "-stdlib=libc++"
 
+FILES:${PN} += "${libdir}/mimalloc-3.2*"
+
 # Added for 2.52.x
 PACKAGECONFIG[libhyphen] = "-DUSE_LIBHYPHEN=ON,-DUSE_LIBHYPHEN=OFF,libhyphen"


### PR DESCRIPTION
Changes:

- Update patch '0001-Add-LAYER_BASED_SVG_ENGINE-envvar_v2.50.patch'.
- Update 'wpewebkit_2.50.%.bbappend' to include '/usr/bin/mimalloc-3.2'.

Maintenance-Type: ci