### PR TITLE
wpewebkit: disable vulkan and precompiled headers for nightly

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit_2.52.%.bbappend
+++ b/recipes-browser/wpewebkit/wpewebkit_2.52.%.bbappend
@@ -11,6 +11,9 @@ PV:class-devupstream = "trunk"
 
 RCONFLICTS:${PN}:class-devupstream = ""
 
+EXTRA_OECMAKE:append:class-devupstream = " -DUSE_VULKAN=OFF"
+EXTRA_OECMAKE:append:class-devupstream = " -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON"
+
 PACKAGECONFIG:append = " wpe-platform"
 PACKAGECONFIG:remove = "speech-synthesis"
 


### PR DESCRIPTION
After change: https://github.com/WebKit/WebKit/commit/1335013d40be7daa006d2c064f695128e93fa666 compilation of WebKit fails with errors: error: function-like macro 'CPU' is not defined. It is caused by using precompiled headers and clang compiler.

This change is needed to make possible to build WPE image with latest main with clang.