### PR TITLE
ci: Pin chromium-driver to 142.0.7444.59

### DIFF
--- a/.ci/robot_framework/init-robot.sh
+++ b/.ci/robot_framework/init-robot.sh
@@ -16,7 +16,7 @@ apt-get update -y
 apt-get install -y git ssh \
     build-essential \
     imagemagick tesseract-ocr ghostscript libdmtx0b libzbar0 \
-    chromium-driver
+    chromium-driver=142.0.7444.59-1~deb13u1
 
 pip install --root-user-action ignore --upgrade pip
 


### PR DESCRIPTION
Pin the chromium-driver package to version 142.0.7444.59-1~deb13u to ensure compatibility with Chrome 142 and prevent CI failure:

```
  chromium  --no-sandbox --headless  --user-data-dir=/tmp/user-data \
      http://foo.bar
  ...
  Trace/breakpoint trap (core dumped)
```

Change-Type: patch
Maintenance-Type: ci